### PR TITLE
ExHeaderPath use DecryptedExHeader.bin file

### DIFF
--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -354,7 +354,7 @@ namespace pk3DS
             ExHeaderPath = null;
             // Input folder path should contain the ExHeader.
                 string[] files = Directory.GetFiles(path);
-                foreach (string fp in from s in files let f = new FileInfo(s) where f.Name.ToLower().StartsWith("exh") && f.Length == 0x800 select s)
+			foreach (string fp in from s in files let f = new FileInfo(s) where (f.Name.ToLower().StartsWith("exh") || f.Name.ToLower().StartsWith("decryptedexh")) && f.Length == 0x800 select s)
                 ExHeaderPath = fp;
 
             return ExHeaderPath != null;


### PR DESCRIPTION
This is a very minor fix. But this allows the user to rebuild a 3ds Rom without having to rename DecryptedExHeader.bin file after extracting a rom with ctrtool.