### PR TITLE
Fix Personal Editor Issues

### DIFF
--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -479,6 +479,8 @@ namespace pk3DS
                 // Set Master Table back
                 for (int i = 0; i < d.Length - 1; i++)
                     d[i].CopyTo(d[d.Length-1], i * d[i].Length);
+
+                Config.GARCPersonal.Files = d;
                 Config.GARCPersonal.Save();
                 Config.InitializePersonal();
 

--- a/pk3DS/Structures/PersonalInfo/PersonalInfoXY.cs
+++ b/pk3DS/Structures/PersonalInfo/PersonalInfoXY.cs
@@ -57,8 +57,8 @@ namespace pk3DS
             {
                 if (value?.Length != 3) return;
                 BitConverter.GetBytes((short)value[0]).CopyTo(Data, 0xC);
-                BitConverter.GetBytes((short)value[0]).CopyTo(Data, 0xE);
-                BitConverter.GetBytes((short)value[0]).CopyTo(Data, 0x10);
+                BitConverter.GetBytes((short)value[1]).CopyTo(Data, 0xE);
+                BitConverter.GetBytes((short)value[2]).CopyTo(Data, 0x10);
             }
         }
         public override int Gender { get { return Data[0x12]; } set { Data[0x12] = (byte)value; } }
@@ -80,7 +80,7 @@ namespace pk3DS
             get { return new int[] { Data[0x18], Data[0x19], Data[0x1A] }; }
             set
             {
-                if (value?.Length != 2) return;
+                if (value?.Length != 3) return;
                 Data[0x18] = (byte)value[0];
                 Data[0x19] = (byte)value[1];
                 Data[0x1A] = (byte)value[2];


### PR DESCRIPTION
Changes:
* Set GARCPersonal.Files to the edited table before saving, fixes the not writing issue
* Use correct array indices when saving item slots, fixes the duplicating 50% slot
* Abilities array expected to have 3 values instead of 2, fixes the abilities not saving at all

Ignore the closed PR, I wanted to get rid of the multiple merge from master commits. Didn't add the upstream to the fork last time!