### PR TITLE
Build Definitions & Error Checking

### DIFF
--- a/pk3DS.sln
+++ b/pk3DS.sln
@@ -1,16 +1,24 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual C# Express 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pk3DS", "pk3DS\pk3DS.csproj", "{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Debug|x86.ActiveCfg = Debug|x86
 		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Debug|x86.Build.0 = Debug|x86
+		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Release|x86.ActiveCfg = Release|x86
 		{C4CB2488-2DB9-489F-8B02-A8E872C6C6AB}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/pk3DS/Misc/ErrorWindow.Designer.cs
+++ b/pk3DS/Misc/ErrorWindow.Designer.cs
@@ -45,6 +45,7 @@
             this.B_Continue.TabIndex = 11;
             this.B_Continue.Text = "Continue";
             this.B_Continue.UseVisualStyleBackColor = true;
+            this.B_Continue.Click += new System.EventHandler(this.B_Continue_Click);
             // 
             // B_Abort
             // 
@@ -55,6 +56,7 @@
             this.B_Abort.TabIndex = 10;
             this.B_Abort.Text = "Abort";
             this.B_Abort.UseVisualStyleBackColor = true;
+            this.B_Abort.Click += new System.EventHandler(this.B_Abort_Click);
             // 
             // B_CopyToClipboard
             // 
@@ -65,6 +67,7 @@
             this.B_CopyToClipboard.TabIndex = 9;
             this.B_CopyToClipboard.Text = "Copy to Clipboard";
             this.B_CopyToClipboard.UseVisualStyleBackColor = true;
+            this.B_CopyToClipboard.Click += new System.EventHandler(this.btnCopyToClipboard_Click);
             // 
             // L_ProvideInfo
             // 
@@ -77,7 +80,7 @@
             // 
             // L_Message
             // 
-            this.L_Message.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.L_Message.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.L_Message.Location = new System.Drawing.Point(10, 11);
             this.L_Message.Name = "L_Message";
@@ -87,8 +90,8 @@
             // 
             // T_ExceptionDetails
             // 
-            this.T_ExceptionDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.T_ExceptionDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.T_ExceptionDetails.Location = new System.Drawing.Point(13, 54);
             this.T_ExceptionDetails.Multiline = true;

--- a/pk3DS/Misc/ErrorWindow.Designer.cs
+++ b/pk3DS/Misc/ErrorWindow.Designer.cs
@@ -1,0 +1,129 @@
+﻿namespace pk3DS
+{
+    partial class ErrorWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.B_Continue = new System.Windows.Forms.Button();
+            this.B_Abort = new System.Windows.Forms.Button();
+            this.B_CopyToClipboard = new System.Windows.Forms.Button();
+            this.L_ProvideInfo = new System.Windows.Forms.Label();
+            this.L_Message = new System.Windows.Forms.Label();
+            this.T_ExceptionDetails = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // B_Continue
+            // 
+            this.B_Continue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.B_Continue.Location = new System.Drawing.Point(332, 203);
+            this.B_Continue.Name = "B_Continue";
+            this.B_Continue.Size = new System.Drawing.Size(75, 23);
+            this.B_Continue.TabIndex = 11;
+            this.B_Continue.Text = "Continue";
+            this.B_Continue.UseVisualStyleBackColor = true;
+            // 
+            // B_Abort
+            // 
+            this.B_Abort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.B_Abort.Location = new System.Drawing.Point(413, 203);
+            this.B_Abort.Name = "B_Abort";
+            this.B_Abort.Size = new System.Drawing.Size(75, 23);
+            this.B_Abort.TabIndex = 10;
+            this.B_Abort.Text = "Abort";
+            this.B_Abort.UseVisualStyleBackColor = true;
+            // 
+            // B_CopyToClipboard
+            // 
+            this.B_CopyToClipboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.B_CopyToClipboard.Location = new System.Drawing.Point(13, 203);
+            this.B_CopyToClipboard.Name = "B_CopyToClipboard";
+            this.B_CopyToClipboard.Size = new System.Drawing.Size(164, 23);
+            this.B_CopyToClipboard.TabIndex = 9;
+            this.B_CopyToClipboard.Text = "Copy to Clipboard";
+            this.B_CopyToClipboard.UseVisualStyleBackColor = true;
+            // 
+            // L_ProvideInfo
+            // 
+            this.L_ProvideInfo.AutoSize = true;
+            this.L_ProvideInfo.Location = new System.Drawing.Point(10, 38);
+            this.L_ProvideInfo.Name = "L_ProvideInfo";
+            this.L_ProvideInfo.Size = new System.Drawing.Size(269, 13);
+            this.L_ProvideInfo.TabIndex = 8;
+            this.L_ProvideInfo.Text = "Please provide this information when reporting this error:";
+            // 
+            // L_Message
+            // 
+            this.L_Message.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_Message.Location = new System.Drawing.Point(10, 11);
+            this.L_Message.Name = "L_Message";
+            this.L_Message.Size = new System.Drawing.Size(478, 27);
+            this.L_Message.TabIndex = 7;
+            this.L_Message.Text = "An unknown error has occurred.";
+            // 
+            // T_ExceptionDetails
+            // 
+            this.T_ExceptionDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.T_ExceptionDetails.Location = new System.Drawing.Point(13, 54);
+            this.T_ExceptionDetails.Multiline = true;
+            this.T_ExceptionDetails.Name = "T_ExceptionDetails";
+            this.T_ExceptionDetails.ReadOnly = true;
+            this.T_ExceptionDetails.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.T_ExceptionDetails.Size = new System.Drawing.Size(475, 143);
+            this.T_ExceptionDetails.TabIndex = 6;
+            // 
+            // ErrorWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(499, 236);
+            this.Controls.Add(this.B_Continue);
+            this.Controls.Add(this.B_Abort);
+            this.Controls.Add(this.B_CopyToClipboard);
+            this.Controls.Add(this.L_ProvideInfo);
+            this.Controls.Add(this.L_Message);
+            this.Controls.Add(this.T_ExceptionDetails);
+            this.MinimumSize = new System.Drawing.Size(515, 275);
+            this.Name = "ErrorWindow";
+            this.Text = "Error";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button B_Continue;
+        private System.Windows.Forms.Button B_Abort;
+        private System.Windows.Forms.Button B_CopyToClipboard;
+        private System.Windows.Forms.Label L_ProvideInfo;
+        private System.Windows.Forms.Label L_Message;
+        private System.Windows.Forms.TextBox T_ExceptionDetails;
+    }
+}

--- a/pk3DS/Misc/ErrorWindow.cs
+++ b/pk3DS/Misc/ErrorWindow.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace pk3DS
+{
+    public partial class ErrorWindow : Form
+    {
+        public static DialogResult ShowErrorDialog(string friendlyMessage, Exception ex, bool allowContinue)
+        {
+            var lang = System.Threading.Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
+            var dialog = new ErrorWindow(lang)
+            {
+                ShowContinue = allowContinue,
+                Message = friendlyMessage,
+                Error = ex
+            };
+            var dialogResult = dialog.ShowDialog();
+            if (dialogResult == DialogResult.Abort)
+            {
+                Environment.Exit(1);
+            }
+            return dialogResult;
+        }
+
+        public ErrorWindow()
+        {
+            InitializeComponent();
+        }
+
+        public ErrorWindow(string lang) : this()
+        {
+            Util.TranslateInterface(this, lang);
+        }
+
+        /// <summary>
+        /// Gets or sets whether or not the "Continue" button is visible.
+        /// </summary>
+        /// <remarks>For UI exceptions, continuing could be safe.
+        /// For application exceptions, continuing is not possible, so the button should not be shown.</remarks>
+        public bool ShowContinue
+        {
+            get
+            {
+                return B_Continue.Visible;
+            }
+            set
+            {
+                B_Continue.Visible = value;
+            }
+        }
+
+        /// <summary>
+        /// Friendly, context-specific method shown to the user.
+        /// </summary>
+        /// <remarks>This property is intended to be a user-friendly context-specific message about what went wrong.
+        /// For example: "An error occurred while attempting to automatically load the save file."</remarks>
+        public string Message
+        {
+            get
+            {
+                return L_Message.Text;
+            }
+            set
+            {
+                L_Message.Text = value;
+            }
+        }
+
+        public Exception Error
+        {
+            get
+            {
+                return _error;
+            }
+            set
+            {
+                _error = value;
+                UpdateExceptionDetailsMessage();
+            }
+        }
+        private Exception _error;
+
+        private void UpdateExceptionDetailsMessage()
+        {
+            var details = new StringBuilder();
+            details.AppendLine("Exception Details:");
+            details.AppendLine(Error.ToString());
+            details.AppendLine();
+
+            details.AppendLine("Loaded Assemblies:");
+            details.AppendLine("--------------------");
+            try
+            {
+                foreach (var item in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    details.AppendLine(item.FullName);
+                    details.AppendLine(item.Location);
+                    details.AppendLine();
+                }
+            }
+            catch (Exception ex)
+            {
+                details.AppendLine("An error occurred while listing the Loaded Assemblies:");
+                details.AppendLine(ex.ToString());
+            }
+            details.AppendLine("--------------------");
+
+            // Include message in case it contains important information, like a file path.
+            details.AppendLine("User Message:");
+            details.AppendLine(Message);
+
+            T_ExceptionDetails.Text = details.ToString();
+        }
+
+        private void btnCopyToClipboard_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(T_ExceptionDetails.Text);
+        }
+
+        private void B_Continue_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void B_Abort_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Abort;
+            Close();
+        }
+
+    }
+}

--- a/pk3DS/Misc/ErrorWindow.resx
+++ b/pk3DS/Misc/ErrorWindow.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/pk3DS/Program.cs
+++ b/pk3DS/Program.cs
@@ -35,7 +35,7 @@ namespace pk3DS
             try
             {
                 // Todo: make this translatable
-                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred.\nYou can continue running the program (albeit with potential side-effects), but please report this error.", t.Exception, true);
+                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred." + Environment.NewLine + "You can continue running the program (albeit with potential side-effects), but please report this error.", t.Exception, true);
             }
             catch
             {
@@ -65,7 +65,7 @@ namespace pk3DS
             {
                 var ex = (Exception)e.ExceptionObject;
                 // Todo: make this translatable
-                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred.\nThe program must now close.", ex, false);
+                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred." + Environment.NewLine + "The program must now close.", ex, false);
             }
             catch
             {

--- a/pk3DS/Program.cs
+++ b/pk3DS/Program.cs
@@ -1,19 +1,84 @@
 ﻿using System;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace pk3DS
 {
     static class Program
     {
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        private static void Main()
         {
+            // Add the event handler for handling UI thread exceptions to the event.
+            Application.ThreadException += UIThreadException;
+
+            // Set the unhandled exception mode to force all Windows Forms errors to go through our handler.
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+
+            // Add the event handler for handling non-UI thread exceptions to the event. 
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+
+            // Run the application
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Main());
+        }
+
+        // Handle the UI exceptions by showing a dialog box, and asking the user whether or not they wish to abort execution.
+        private static void UIThreadException(object sender, ThreadExceptionEventArgs t)
+        {
+            DialogResult result = DialogResult.Cancel;
+            try
+            {
+                // Todo: make this translatable
+                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred.\nYou can continue running the program (albeit with potential side-effects), but please report this error.", t.Exception, true);
+            }
+            catch
+            {
+                try
+                {
+                    // Todo: make this translatable
+                    MessageBox.Show("A fatal error has occurred in PKHeX, and the details could not be displayed.  Please report this to the author.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                }
+                finally
+                {
+                    Application.Exit();
+                }
+            }
+
+            // Exits the program when the user clicks Abort.
+            if (result == DialogResult.Abort)
+                Application.Exit();
+        }
+
+        // Handle the UI exceptions by showing a dialog box, and asking the user whether
+        // or not they wish to abort execution.
+        // NOTE: This exception cannot be kept from terminating the application - it can only 
+        // log the event, and inform the user about it. 
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            try
+            {
+                var ex = (Exception)e.ExceptionObject;
+                // Todo: make this translatable
+                ErrorWindow.ShowErrorDialog("An unhandled exception has occurred.\nThe program must now close.", ex, false);
+            }
+            catch
+            {
+                try
+                {
+                    // Todo: make this translatable
+                    MessageBox.Show("A fatal non-UI error has occurred in PKHeX, and the details could not be displayed.  Please report this to the author.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                }
+                finally
+                {
+                    Application.Exit();
+                }
+            }
         }
     }
 }

--- a/pk3DS/pk3DS.csproj
+++ b/pk3DS/pk3DS.csproj
@@ -15,7 +15,7 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/pk3DS/pk3DS.csproj
+++ b/pk3DS/pk3DS.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,12 +30,34 @@
     <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\x86\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/pk3DS/pk3DS.csproj
+++ b/pk3DS/pk3DS.csproj
@@ -62,8 +62,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="3DS\AES.cs" />
@@ -88,6 +90,12 @@
     <Compile Include="Game\GARCReference.cs" />
     <Compile Include="Game\TextReference.cs" />
     <Compile Include="Game\TextVariableCode.cs" />
+    <Compile Include="Misc\ErrorWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Misc\ErrorWindow.Designer.cs">
+      <DependentUpon>ErrorWindow.cs</DependentUpon>
+    </Compile>
     <Compile Include="Structures\EncounterStatic.cs" />
     <Compile Include="Structures\Gen7\EncounterGift7.cs" />
     <Compile Include="Structures\Gen7\EncounterStatic7.cs" />
@@ -405,6 +413,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Misc\About.resx">
       <DependentUpon>About.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Misc\ErrorWindow.resx">
+      <DependentUpon>ErrorWindow.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Subforms\Gen7\EggMoveEditor7.resx">
       <DependentUpon>EggMoveEditor7.cs</DependentUpon>


### PR DESCRIPTION
In response to #95, this PR will:
- Create a solution build configuration that targets Any CPU.  This will default to x64 on computers that are capable of running x64 software.
- Add the error window I wrote for PKHeX to aid in debugging vague crashes
- Make the existing Debug x86 build configuration target x32, to correspond to its name.  Oddly enough the Release x86 configuration was already configured this way.

(The [build](http://teamcity.skyeditor.org/viewLog.html?buildId=5885&tab=buildResultsDiv&buildTypeId=Pk3ds_Pk3dsCi) passes BTW, I just don't have build status reporting enabled for this project at the moment.)