### PR TITLE
Add close functions to multiple editors + CRO editing prompt for MartEditor7

### DIFF
--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -879,6 +879,10 @@ namespace pk3DS
                     break;
 
                 case 7:
+                    if (threadActive()) return;
+                    if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo,
+                        "CRO Editing causes crashes if you do not patch the RO module.", "Continue anyway?"))
+                        return;
                     if (RomFSPath != null) new MartEditor7().Show();
                     break;
             }

--- a/pk3DS/Subforms/Gen6/MartEditor6.cs
+++ b/pk3DS/Subforms/Gen6/MartEditor6.cs
@@ -138,6 +138,7 @@ namespace pk3DS
         {
             if (entry > -1) setList();
             File.WriteAllBytes(codebin, data);
+            Close();
         }
         private void B_Cancel_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen6/PickupEditor6.cs
+++ b/pk3DS/Subforms/Gen6/PickupEditor6.cs
@@ -104,6 +104,7 @@ namespace pk3DS
         {
             setList();
             File.WriteAllBytes(codebin, data);
+            Close();
         }
         private void B_Cancel_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/MartEditor7.cs
+++ b/pk3DS/Subforms/Gen7/MartEditor7.cs
@@ -109,6 +109,7 @@ namespace pk3DS
             if (entry > -1) setList();
             if (entryBP > -1) setListBP();
             File.WriteAllBytes(CROPath, data);
+            Close();
         }
         private void B_Cancel_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
These are the only editors within pk3DS that do not close the form when saving; done to keep consistency among all editors.

Edit: also added a prompt regarding patching the RO Module before opening MartEditor7.