### PR TITLE
Add error handling to text editing

### DIFF
--- a/pk3DS.Core/TextFile.cs
+++ b/pk3DS.Core/TextFile.cs
@@ -104,7 +104,15 @@ namespace pk3DS.Core
                     string text = (value[i] ?? "").Trim();
                     if (text.Length == 0 && SETEMPTYTEXT)
                         text = $"[~ {i}]";
-                    byte[] DecryptedLineData = getLineData(Config, text);
+                    byte[] DecryptedLineData;
+                    try
+                    {
+                        DecryptedLineData = getLineData(Config, text);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"{ex.GetType()} at line {i}: {ex.Message}");
+                    }
                     lineData[i] = cryptLineData(DecryptedLineData, key);
                     if (lineData[i].Length % 4 == 2)
                         Array.Resize(ref lineData[i], lineData[i].Length + 2);
@@ -289,10 +297,18 @@ namespace pk3DS.Core
 
             if (!noArgs)
             {
-                string[] args = text.Substring(bracket + 1, text.Length - bracket - 2).Split(',');
+                string strArgs = text.Substring(bracket + 1, text.Length - bracket - 2);
+                string[] args = strArgs.Split(',');
                 vals.Add((ushort)(1 + args.Length));
                 vals.Add(varVal);
-                vals.AddRange(args.Select(t => Convert.ToUInt16(t, 16)));
+                try
+                {
+                    vals.AddRange(args.Select(t => Convert.ToUInt16(t, 16)));
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"{ex.GetType()} in args '{strArgs}'");
+                }
             }
             else
             {
@@ -306,7 +322,7 @@ namespace pk3DS.Core
         {
             var v = config.getVariableCode(variable);
             if (v != null)
-                return (ushort) v.Code;
+                return (ushort)v.Code;
 
             try
             {
@@ -319,7 +335,7 @@ namespace pk3DS.Core
             var v = config.getVariableName(variable);
             return v == null ? variable.ToString("X4") : v.Name;
         }
-        
+
         // Exposed Methods
         public static string[] getStrings(GameConfig config, byte[] data)
         {
@@ -329,7 +345,7 @@ namespace pk3DS.Core
         }
         public static byte[] getBytes(GameConfig config, string[] lines)
         {
-            return new TextFile (config) { Lines = lines }.Data;
+            return new TextFile(config) { Lines = lines }.Data;
         }
     }
 }

--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -437,9 +437,44 @@ namespace pk3DS
             {
                 var g = Config.GARCGameText;
                 string[][] files = Config.GameTextStrings;
-                Invoke((Action)(() => new TextEditor(files, "gametext").ShowDialog()));
-                g.Files = files.Select(x => TextFile.getBytes(Main.Config, x)).ToArray();
-                g.Save();
+                string error;
+                do // Until there is no error
+                {
+                    error = null;
+                    Invoke((Action)(() => new TextEditor(files, "gametext").ShowDialog()));
+                    byte[][] data = new byte[files.Length][];
+                    for (int i = 0; i < files.Length; i++) // For every single file...
+                    {
+                        // Try to convert it.
+                        try
+                        {
+                            data[i] = TextFile.getBytes(Main.Config, files[i]);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Because of the for loop, the user can see the
+                            // file at fault
+                            error = $"{ex.GetType()} in text file {i}: {ex.Message}";
+                            break;
+                        }
+                    }
+                    if (error == null)
+                    {
+                        g.Files = data;
+                        g.Save();
+                    }
+                    else
+                    {
+                        // Give the user the option to save their work after
+                        // an error occured
+                        MessageBox.Show("Error:\r\n" + error + "\r\nNo changes made.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        if (MessageBox.Show("Discard text changes?", "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Question)
+                            == DialogResult.Yes)
+                        {
+                            error = null;
+                        }
+                    }
+                } while (error != null);
             }).Start();
         }
         private void B_StoryText_Click(object sender, EventArgs e)
@@ -449,9 +484,44 @@ namespace pk3DS
             {
                 var g = Config.getGARCData("storytext");
                 string[][] files = g.Files.Select(file => new TextFile(Config, file).Lines).ToArray();
-                Invoke((Action)(() => new TextEditor(files, "storytext").ShowDialog()));
-                g.Files = files.Select(x => TextFile.getBytes(Main.Config, x)).ToArray();
-                g.Save();
+                string error;
+                do // Until there is no error
+                {
+                    error = null;
+                    Invoke((Action)(() => new TextEditor(files, "storytext").ShowDialog()));
+                    byte[][] data = new byte[files.Length][];
+                    for (int i = 0; i < files.Length; i++) // For every single file...
+                    {
+                        // Try to convert it.
+                        try
+                        {
+                            data[i] = TextFile.getBytes(Main.Config, files[i]);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Because of the for loop, the user can see the
+                            // file at fault
+                            error = $"{ex.GetType()} in text file {i}: {ex.Message}";
+                            break;
+                        }
+                    }
+                    if (error == null)
+                    {
+                        g.Files = data;
+                        g.Save();
+                    }
+                    else
+                    {
+                        // Give the user the option to save their work after
+                        // an error occured
+                        MessageBox.Show("Error:\r\n" + error + "\r\nNo changes made.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        if (MessageBox.Show("Discard text changes?", "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Question)
+                            == DialogResult.Yes)
+                        {
+                            error = null;
+                        }
+                    }
+                } while (error != null);
             }).Start();
         }
         private void B_Maison_Click(object sender, EventArgs e)


### PR DESCRIPTION
I added proper exception handling to the Game Text and Story Text editing functions.
Before that, the application crashed on things like wrong escapations (e.g. \m, \O) and mistyped variable parameters (OOFF instead of 00FF).
Now, it tells the user exactly where the error is and asks if they want to continue editing.
I hope my code isn't too spaghetti-ish.