### PR TITLE
Add Secret Power to TM rand banlist

### DIFF
--- a/pk3DS/Subforms/Gen6/TMHMEditor6.cs
+++ b/pk3DS/Subforms/Gen6/TMHMEditor6.cs
@@ -161,7 +161,7 @@ namespace pk3DS
             int[] randomMoves = Enumerable.Range(1, movelist.Length - 1).Select(i => i).ToArray();
             Util.Shuffle(randomMoves);
 
-            int[] banned = { 15, 19, 57, 70, 127, 249, 291, 148 };
+            int[] banned = { 15, 19, 57, 70, 127, 249, 291, 148, 290 }; // Moves with overworld effects
             int ctr = 0;
 
             for (int i = 0; i < dgvTM.Rows.Count; i++)


### PR DESCRIPTION
TM94 in XY is Rock Smash (was already banned). In ORAS, Rock Smash is an HM and TM94 becomes Secret Power.