### PR TITLE
Make getter of PersonalInfo.FormStatsIndex public

### DIFF
--- a/pk3DS.Core/Structures/PersonalInfo/PersonalInfo.cs
+++ b/pk3DS.Core/Structures/PersonalInfo/PersonalInfo.cs
@@ -44,7 +44,7 @@
         public abstract int [] Abilities { get; set; }
         public abstract int EscapeRate { get; set; }
         public virtual int FormeCount { get; set; }
-        protected internal virtual int FormStatsIndex { get; set; }
+        public virtual int FormStatsIndex { get; protected internal set; }
         public virtual int FormeSprite { get; set; }
         public abstract int BaseEXP { get; set; }
         public abstract int Color { get; set; }

--- a/pk3DS.Core/Structures/PersonalInfo/PersonalInfoXY.cs
+++ b/pk3DS.Core/Structures/PersonalInfo/PersonalInfoXY.cs
@@ -87,7 +87,7 @@ namespace pk3DS.Core.Structures.PersonalInfo
             }
         }
         public override int EscapeRate { get { return Data[0x1B]; } set { Data[0x1B] = (byte)value; } }
-        protected internal override int FormStatsIndex { get { return BitConverter.ToUInt16(Data, 0x1C); } set { BitConverter.GetBytes((ushort)value).CopyTo(Data, 0x1C); } }
+        public override int FormStatsIndex { get { return BitConverter.ToUInt16(Data, 0x1C); } protected internal set { BitConverter.GetBytes((ushort)value).CopyTo(Data, 0x1C); } }
         public override int FormeSprite { get { return BitConverter.ToUInt16(Data, 0x1E); } set { BitConverter.GetBytes((ushort)value).CopyTo(Data, 0x1E); } }
         public override int FormeCount { get { return Data[0x20]; } set { Data[0x20] = (byte)value; } }
         public override int Color { get { return Data[0x21]; } set { Data[0x21] = (byte)value; } }


### PR DESCRIPTION
It's a quick solution allowing external programs like the Project Pokémon Pokédex to calculate references from personal entries to corresponding alt-form personal entries