### PR TITLE
Implement item randomization for static/gift PKM

### DIFF
--- a/pk3DS/Subforms/Gen6/GiftEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.Designer.cs
@@ -78,6 +78,7 @@
             this.CHK_G1 = new System.Windows.Forms.CheckBox();
             this.NUD_LevelBoost = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV0)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV2)).BeginInit();
@@ -561,9 +562,9 @@
             // 
             this.L_Mega.Location = new System.Drawing.Point(26, 190);
             this.L_Mega.Name = "L_Mega";
-            this.L_Mega.Size = new System.Drawing.Size(101, 33);
+            this.L_Mega.Size = new System.Drawing.Size(113, 33);
             this.L_Mega.TabIndex = 512;
-            this.L_Mega.Text = "XY - Lucario\nORAS - Lati@s";
+            this.L_Mega.Text = "XY - Lucario\nORAS - Latias/Latios";
             this.L_Mega.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // CHK_Mega
@@ -580,6 +581,7 @@
             // 
             // GB_Tweak
             // 
+            this.GB_Tweak.Controls.Add(this.CHK_Item);
             this.GB_Tweak.Controls.Add(this.L_RandOpt);
             this.GB_Tweak.Controls.Add(this.CHK_BST);
             this.GB_Tweak.Controls.Add(this.CHK_E);
@@ -592,7 +594,7 @@
             this.GB_Tweak.Controls.Add(this.CHK_G1);
             this.GB_Tweak.Location = new System.Drawing.Point(7, 62);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 100);
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 108);
             this.GB_Tweak.TabIndex = 509;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Randomization Tweaks";
@@ -747,6 +749,16 @@
             this.CHK_Level.Text = "Multiply PKM Level by";
             this.CHK_Level.UseVisualStyleBackColor = true;
             // 
+            // CHK_Item
+            // 
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Location = new System.Drawing.Point(9, 81);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 296;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
+            // 
             // GiftEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -839,5 +851,6 @@
         private System.Windows.Forms.CheckBox CHK_G1;
         private System.Windows.Forms.CheckBox CHK_Mega;
         private System.Windows.Forms.Label L_Mega;
+        private System.Windows.Forms.CheckBox CHK_Item;
     }
 }

--- a/pk3DS/Subforms/Gen6/GiftEditor6.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.cs
@@ -187,20 +187,27 @@ namespace pk3DS
                 rBST = CHK_BST.Checked,
             };
             specrand.Initialize();
+            var helditems = Randomizer.getRandomItemList();
             for (int i = 0; i < LB_Gifts.Items.Count; i++)
             {
                 LB_Gifts.SelectedIndex = i;
                 int species = CB_Species.SelectedIndex;
-                if (MegaDictionary.Values.Any(z => z.Contains(CB_HeldItem.SelectedIndex))) // mega stone gift pkm (only lucario?)
+
+                if (MegaDictionary.Values.Any(z => z.Contains(CB_HeldItem.SelectedIndex))) // Mega Stone Gifts (Lucario, Latias/Latios)
                 {
                     if (!CHK_Mega.Checked)
-                        continue; // skip Lucario, battle needs to mega evolve
+                        continue; // skip Lucario, battle needs to Mega Evolve
 
                     int[] items = GetRandomMega(out species);
                     CB_HeldItem.SelectedIndex = items[Util.rand.Next(0, items.Length)];
                 }
                 else
+                {
                     species = specrand.GetRandomSpecies(species);
+
+                    if (CHK_Item.Checked)
+                        CB_HeldItem.SelectedIndex = helditems[Util.rnd32() % helditems.Length];
+                }
 
                 CB_Species.SelectedIndex = species;
                 NUD_Form.Value = formrand.GetRandomForme(species);

--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.Designer.cs
@@ -65,6 +65,7 @@
             this.CHK_G1 = new System.Windows.Forms.CheckBox();
             this.NUD_LevelBoost = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Level)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Form)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Ability)).BeginInit();
@@ -334,6 +335,7 @@
             // 
             // GB_Tweak
             // 
+            this.GB_Tweak.Controls.Add(this.CHK_Item);
             this.GB_Tweak.Controls.Add(this.L_RandOpt);
             this.GB_Tweak.Controls.Add(this.CHK_BST);
             this.GB_Tweak.Controls.Add(this.CHK_E);
@@ -346,7 +348,7 @@
             this.GB_Tweak.Controls.Add(this.CHK_G1);
             this.GB_Tweak.Location = new System.Drawing.Point(7, 67);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 100);
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 107);
             this.GB_Tweak.TabIndex = 509;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Randomization Tweaks";
@@ -501,6 +503,16 @@
             this.CHK_Level.Text = "Multiply PKM Level by";
             this.CHK_Level.UseVisualStyleBackColor = true;
             // 
+            // CHK_Item
+            // 
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Location = new System.Drawing.Point(9, 81);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 295;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
+            // 
             // StaticEncounterEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -573,5 +585,6 @@
         private System.Windows.Forms.CheckBox CHK_G3;
         private System.Windows.Forms.CheckBox CHK_G2;
         private System.Windows.Forms.CheckBox CHK_G1;
+        private System.Windows.Forms.CheckBox CHK_Item;
     }
 }

--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
@@ -139,6 +139,7 @@ namespace pk3DS
                 rBST = CHK_BST.Checked,
             };
             specrand.Initialize();
+            var items = Randomizer.getRandomItemList();
             for (int i = 0; i < LB_Encounters.Items.Count; i++)
             {
                 LB_Encounters.SelectedIndex = i;
@@ -148,6 +149,9 @@ namespace pk3DS
                 CB_Species.SelectedIndex = species;
                 NUD_Form.Value = formrand.GetRandomForme(species);
                 NUD_Gender.Value = 0; // random
+
+                if (CHK_Item.Checked)
+                    CB_HeldItem.SelectedIndex = items[Util.rnd32() % items.Length];
 
                 if (CHK_Level.Checked)
                     NUD_Level.Value = Randomizer.getModifiedLevel((int)NUD_Level.Value, NUD_LevelBoost.Value);

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
@@ -30,6 +30,8 @@
         {
             this.TC_Tabs = new System.Windows.Forms.TabControl();
             this.Tab_Gifts = new System.Windows.Forms.TabPage();
+            this.NUD_GGender = new System.Windows.Forms.NumericUpDown();
+            this.CHK_G_Lock = new System.Windows.Forms.CheckBox();
             this.CB_GHeldItem = new System.Windows.Forms.ComboBox();
             this.L_GHeldItem = new System.Windows.Forms.Label();
             this.CB_GSpecies = new System.Windows.Forms.ComboBox();
@@ -89,10 +91,10 @@
             this.B_Starters = new System.Windows.Forms.Button();
             this.B_Save = new System.Windows.Forms.Button();
             this.B_Cancel = new System.Windows.Forms.Button();
-            this.CHK_G_Lock = new System.Windows.Forms.CheckBox();
-            this.NUD_GGender = new System.Windows.Forms.NumericUpDown();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             this.TC_Tabs.SuspendLayout();
             this.Tab_Gifts.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_GGender)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GForm)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GLevel)).BeginInit();
             this.Tab_Encounters.SuspendLayout();
@@ -106,7 +108,6 @@
             this.Tab_Randomizer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).BeginInit();
             this.GB_Tweak.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_GGender)).BeginInit();
             this.SuspendLayout();
             // 
             // TC_Tabs
@@ -143,6 +144,33 @@
             this.Tab_Gifts.TabIndex = 2;
             this.Tab_Gifts.Text = "Gifts";
             this.Tab_Gifts.UseVisualStyleBackColor = true;
+            // 
+            // NUD_GGender
+            // 
+            this.NUD_GGender.Location = new System.Drawing.Point(230, 137);
+            this.NUD_GGender.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+            this.NUD_GGender.Name = "NUD_GGender";
+            this.NUD_GGender.Size = new System.Drawing.Size(48, 20);
+            this.NUD_GGender.TabIndex = 20;
+            this.NUD_GGender.Value = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            // 
+            // CHK_G_Lock
+            // 
+            this.CHK_G_Lock.AutoSize = true;
+            this.CHK_G_Lock.Location = new System.Drawing.Point(230, 114);
+            this.CHK_G_Lock.Name = "CHK_G_Lock";
+            this.CHK_G_Lock.Size = new System.Drawing.Size(79, 17);
+            this.CHK_G_Lock.TabIndex = 19;
+            this.CHK_G_Lock.Text = "Shiny Lock";
+            this.CHK_G_Lock.UseVisualStyleBackColor = true;
             // 
             // CB_GHeldItem
             // 
@@ -654,6 +682,7 @@
             // 
             // GB_Tweak
             // 
+            this.GB_Tweak.Controls.Add(this.CHK_Item);
             this.GB_Tweak.Controls.Add(this.CHK_G7);
             this.GB_Tweak.Controls.Add(this.L_RandOpt);
             this.GB_Tweak.Controls.Add(this.CHK_BST);
@@ -829,32 +858,15 @@
             this.B_Cancel.UseVisualStyleBackColor = true;
             this.B_Cancel.Click += new System.EventHandler(this.B_Cancel_Click);
             // 
-            // CHK_G_Lock
+            // CHK_Item
             // 
-            this.CHK_G_Lock.AutoSize = true;
-            this.CHK_G_Lock.Location = new System.Drawing.Point(230, 114);
-            this.CHK_G_Lock.Name = "CHK_G_Lock";
-            this.CHK_G_Lock.Size = new System.Drawing.Size(79, 17);
-            this.CHK_G_Lock.TabIndex = 19;
-            this.CHK_G_Lock.Text = "Shiny Lock";
-            this.CHK_G_Lock.UseVisualStyleBackColor = true;
-            // 
-            // NUD_GGender
-            // 
-            this.NUD_GGender.Location = new System.Drawing.Point(230, 137);
-            this.NUD_GGender.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.NUD_GGender.Name = "NUD_GGender";
-            this.NUD_GGender.Size = new System.Drawing.Size(48, 20);
-            this.NUD_GGender.TabIndex = 20;
-            this.NUD_GGender.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Location = new System.Drawing.Point(128, 79);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 297;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
             // 
             // StaticEncounterEditor7
             // 
@@ -869,6 +881,7 @@
             this.TC_Tabs.ResumeLayout(false);
             this.Tab_Gifts.ResumeLayout(false);
             this.Tab_Gifts.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_GGender)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GForm)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GLevel)).EndInit();
             this.Tab_Encounters.ResumeLayout(false);
@@ -886,7 +899,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).EndInit();
             this.GB_Tweak.ResumeLayout(false);
             this.GB_Tweak.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_GGender)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -956,5 +968,6 @@
         private System.Windows.Forms.CheckBox CHK_ShinyLock;
         private System.Windows.Forms.NumericUpDown NUD_GGender;
         private System.Windows.Forms.CheckBox CHK_G_Lock;
+        private System.Windows.Forms.CheckBox CHK_Item;
     }
 }

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -334,6 +334,7 @@ namespace pk3DS
 
             var specrand = getRandomizer();
             var formrand = new FormRandomizer(Main.Config) { AllowMega = false, AllowAlolanForm = true };
+            var items = Randomizer.getRandomItemList();
 
             // Assign Species
             for (int i = 0; i < 3; i++)
@@ -341,6 +342,9 @@ namespace pk3DS
                 var t = Gifts[i];
                 t.Species = specrand.GetRandomSpecies(oldStarters[i]);
                 t.Form = formrand.GetRandomForme(t.Species);
+
+                if (CHK_Item.Checked)
+                    t.HeldItem = items[Util.rnd32() % items.Length];
 
                 // no level boosting
             }
@@ -362,12 +366,16 @@ namespace pk3DS
             var specrand = getRandomizer();
             var formrand = new FormRandomizer(Main.Config) { AllowMega = false, AllowAlolanForm = true };
             var move = new LearnsetRandomizer(Main.Config, Main.Config.Learnsets);
+            var items = Randomizer.getRandomItemList();
 
             for (int i = 3; i < Gifts.Length; i++) // Skip Starters
             {
                 var t = Gifts[i];
                 t.Species = specrand.GetRandomSpecies(t.Species);
                 t.Form = formrand.GetRandomForme(t.Species);
+
+                if (CHK_Item.Checked)
+                    t.HeldItem = items[Util.rnd32() % items.Length];
 
                 if (CHK_Level.Checked)
                     t.Level = Randomizer.getModifiedLevel(t.Level, NUD_LevelBoost.Value);
@@ -378,6 +386,9 @@ namespace pk3DS
                 t.Form = formrand.GetRandomForme(t.Species);
                 t.RelearnMoves = move.GetCurrentMoves(t.Species, t.Form, t.Level, 4);
 
+                if (CHK_Item.Checked)
+                    t.HeldItem = items[Util.rnd32() % items.Length];
+
                 if (CHK_Level.Checked)
                     t.Level = Randomizer.getModifiedLevel(t.Level, NUD_LevelBoost.Value);
             }
@@ -386,6 +397,9 @@ namespace pk3DS
                 t.Species = specrand.GetRandomSpecies(t.Species);
                 t.Form = formrand.GetRandomForme(t.Species);
                 t.TradeRequestSpecies = specrand.GetRandomSpecies(t.TradeRequestSpecies);
+
+                if (CHK_Item.Checked)
+                    t.HeldItem = items[Util.rnd32() % items.Length];
 
                 if (CHK_Level.Checked)
                     t.Level = Randomizer.getModifiedLevel(t.Level, NUD_LevelBoost.Value);


### PR DESCRIPTION
Also prevents overwriting Mega Gift replacement (for Gen 6). If that is checked, it will do Mega-for-Mega, and then randomize Held Items for everything else.