### PR TITLE
Random Mega Form option for Static Editors

### DIFF
--- a/pk3DS/Subforms/Gen6/GiftEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.Designer.cs
@@ -66,6 +66,7 @@
             this.L_Mega = new System.Windows.Forms.Label();
             this.CHK_Mega = new System.Windows.Forms.CheckBox();
             this.GB_Tweak = new System.Windows.Forms.GroupBox();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             this.L_RandOpt = new System.Windows.Forms.Label();
             this.CHK_BST = new System.Windows.Forms.CheckBox();
             this.CHK_E = new System.Windows.Forms.CheckBox();
@@ -78,7 +79,6 @@
             this.CHK_G1 = new System.Windows.Forms.CheckBox();
             this.NUD_LevelBoost = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
-            this.CHK_Item = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV0)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_IV2)).BeginInit();
@@ -594,10 +594,22 @@
             this.GB_Tweak.Controls.Add(this.CHK_G1);
             this.GB_Tweak.Location = new System.Drawing.Point(7, 62);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 108);
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 99);
             this.GB_Tweak.TabIndex = 509;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Randomization Tweaks";
+            // 
+            // CHK_Item
+            // 
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Checked = true;
+            this.CHK_Item.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_Item.Location = new System.Drawing.Point(9, 79);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 296;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
             // 
             // L_RandOpt
             // 
@@ -748,16 +760,6 @@
             this.CHK_Level.TabIndex = 302;
             this.CHK_Level.Text = "Multiply PKM Level by";
             this.CHK_Level.UseVisualStyleBackColor = true;
-            // 
-            // CHK_Item
-            // 
-            this.CHK_Item.AutoSize = true;
-            this.CHK_Item.Location = new System.Drawing.Point(9, 81);
-            this.CHK_Item.Name = "CHK_Item";
-            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
-            this.CHK_Item.TabIndex = 296;
-            this.CHK_Item.Text = "Random Held Items";
-            this.CHK_Item.UseVisualStyleBackColor = true;
             // 
             // GiftEditor6
             // 

--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.Designer.cs
@@ -53,6 +53,7 @@
             this.label1 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.GB_Tweak = new System.Windows.Forms.GroupBox();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             this.L_RandOpt = new System.Windows.Forms.Label();
             this.CHK_BST = new System.Windows.Forms.CheckBox();
             this.CHK_E = new System.Windows.Forms.CheckBox();
@@ -65,7 +66,7 @@
             this.CHK_G1 = new System.Windows.Forms.CheckBox();
             this.NUD_LevelBoost = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
-            this.CHK_Item = new System.Windows.Forms.CheckBox();
+            this.CHK_AllowMega = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Level)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Form)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Ability)).BeginInit();
@@ -335,6 +336,7 @@
             // 
             // GB_Tweak
             // 
+            this.GB_Tweak.Controls.Add(this.CHK_AllowMega);
             this.GB_Tweak.Controls.Add(this.CHK_Item);
             this.GB_Tweak.Controls.Add(this.L_RandOpt);
             this.GB_Tweak.Controls.Add(this.CHK_BST);
@@ -346,12 +348,24 @@
             this.GB_Tweak.Controls.Add(this.CHK_G3);
             this.GB_Tweak.Controls.Add(this.CHK_G2);
             this.GB_Tweak.Controls.Add(this.CHK_G1);
-            this.GB_Tweak.Location = new System.Drawing.Point(7, 67);
+            this.GB_Tweak.Location = new System.Drawing.Point(7, 58);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 107);
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 114);
             this.GB_Tweak.TabIndex = 509;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Randomization Tweaks";
+            // 
+            // CHK_Item
+            // 
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Checked = true;
+            this.CHK_Item.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_Item.Location = new System.Drawing.Point(9, 79);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 295;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
             // 
             // L_RandOpt
             // 
@@ -503,15 +517,15 @@
             this.CHK_Level.Text = "Multiply PKM Level by";
             this.CHK_Level.UseVisualStyleBackColor = true;
             // 
-            // CHK_Item
+            // CHK_AllowMega
             // 
-            this.CHK_Item.AutoSize = true;
-            this.CHK_Item.Location = new System.Drawing.Point(9, 81);
-            this.CHK_Item.Name = "CHK_Item";
-            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
-            this.CHK_Item.TabIndex = 295;
-            this.CHK_Item.Text = "Random Held Items";
-            this.CHK_Item.UseVisualStyleBackColor = true;
+            this.CHK_AllowMega.AutoSize = true;
+            this.CHK_AllowMega.Location = new System.Drawing.Point(9, 94);
+            this.CHK_AllowMega.Name = "CHK_AllowMega";
+            this.CHK_AllowMega.Size = new System.Drawing.Size(155, 17);
+            this.CHK_AllowMega.TabIndex = 296;
+            this.CHK_AllowMega.Text = "Allow Random Mega Forms";
+            this.CHK_AllowMega.UseVisualStyleBackColor = true;
             // 
             // StaticEncounterEditor6
             // 
@@ -586,5 +600,6 @@
         private System.Windows.Forms.CheckBox CHK_G2;
         private System.Windows.Forms.CheckBox CHK_G1;
         private System.Windows.Forms.CheckBox CHK_Item;
+        private System.Windows.Forms.CheckBox CHK_AllowMega;
     }
 }

--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
@@ -150,6 +150,9 @@ namespace pk3DS
                 NUD_Form.Value = formrand.GetRandomForme(species);
                 NUD_Gender.Value = 0; // random
 
+                if (CHK_AllowMega.Checked)
+                    formrand.AllowMega = true;
+
                 if (CHK_Item.Checked)
                     CB_HeldItem.SelectedIndex = items[Util.rnd32() % items.Length];
 

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
@@ -77,6 +77,7 @@
             this.CHK_Level = new System.Windows.Forms.CheckBox();
             this.B_RandAll = new System.Windows.Forms.Button();
             this.GB_Tweak = new System.Windows.Forms.GroupBox();
+            this.CHK_Item = new System.Windows.Forms.CheckBox();
             this.CHK_G7 = new System.Windows.Forms.CheckBox();
             this.L_RandOpt = new System.Windows.Forms.Label();
             this.CHK_BST = new System.Windows.Forms.CheckBox();
@@ -91,7 +92,7 @@
             this.B_Starters = new System.Windows.Forms.Button();
             this.B_Save = new System.Windows.Forms.Button();
             this.B_Cancel = new System.Windows.Forms.Button();
-            this.CHK_Item = new System.Windows.Forms.CheckBox();
+            this.CHK_AllowMega = new System.Windows.Forms.CheckBox();
             this.TC_Tabs.SuspendLayout();
             this.Tab_Gifts.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GGender)).BeginInit();
@@ -682,6 +683,7 @@
             // 
             // GB_Tweak
             // 
+            this.GB_Tweak.Controls.Add(this.CHK_AllowMega);
             this.GB_Tweak.Controls.Add(this.CHK_Item);
             this.GB_Tweak.Controls.Add(this.CHK_G7);
             this.GB_Tweak.Controls.Add(this.L_RandOpt);
@@ -696,10 +698,22 @@
             this.GB_Tweak.Controls.Add(this.CHK_G1);
             this.GB_Tweak.Location = new System.Drawing.Point(52, 100);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 100);
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 130);
             this.GB_Tweak.TabIndex = 508;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Randomization Tweaks";
+            // 
+            // CHK_Item
+            // 
+            this.CHK_Item.AutoSize = true;
+            this.CHK_Item.Checked = true;
+            this.CHK_Item.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_Item.Location = new System.Drawing.Point(9, 94);
+            this.CHK_Item.Name = "CHK_Item";
+            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.TabIndex = 297;
+            this.CHK_Item.Text = "Random Held Items";
+            this.CHK_Item.UseVisualStyleBackColor = true;
             // 
             // CHK_G7
             // 
@@ -858,15 +872,15 @@
             this.B_Cancel.UseVisualStyleBackColor = true;
             this.B_Cancel.Click += new System.EventHandler(this.B_Cancel_Click);
             // 
-            // CHK_Item
+            // CHK_AllowMega
             // 
-            this.CHK_Item.AutoSize = true;
-            this.CHK_Item.Location = new System.Drawing.Point(128, 79);
-            this.CHK_Item.Name = "CHK_Item";
-            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
-            this.CHK_Item.TabIndex = 297;
-            this.CHK_Item.Text = "Random Held Items";
-            this.CHK_Item.UseVisualStyleBackColor = true;
+            this.CHK_AllowMega.AutoSize = true;
+            this.CHK_AllowMega.Location = new System.Drawing.Point(9, 109);
+            this.CHK_AllowMega.Name = "CHK_AllowMega";
+            this.CHK_AllowMega.Size = new System.Drawing.Size(155, 17);
+            this.CHK_AllowMega.TabIndex = 298;
+            this.CHK_AllowMega.Text = "Allow Random Mega Forms";
+            this.CHK_AllowMega.UseVisualStyleBackColor = true;
             // 
             // StaticEncounterEditor7
             // 
@@ -969,5 +983,6 @@
         private System.Windows.Forms.NumericUpDown NUD_GGender;
         private System.Windows.Forms.CheckBox CHK_G_Lock;
         private System.Windows.Forms.CheckBox CHK_Item;
+        private System.Windows.Forms.CheckBox CHK_AllowMega;
     }
 }

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -343,6 +343,9 @@ namespace pk3DS
                 t.Species = specrand.GetRandomSpecies(oldStarters[i]);
                 t.Form = formrand.GetRandomForme(t.Species);
 
+                if (CHK_AllowMega.Checked)
+                    formrand.AllowMega = true;
+
                 if (CHK_Item.Checked)
                     t.HeldItem = items[Util.rnd32() % items.Length];
 


### PR DESCRIPTION
Also changed Random Held Item checkboxes to be set to checked; to stay consistent with Personal/Trainer (plus I dunno anybody who'd be opposed to it). I didn't bother with Gen 6 gifts because of Mega Gifts (2 lazy to find a way of excluding them).