### PR TITLE
Misc additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pk3DS
 pk3DS: A package of Pokémon (3DS) ROM Editing Tools by various contributors.
 
-![RomFS Editing Tools](https://i.imgur.com/WxWOrhd.png)
-![ExeFS Editing Tools](https://i.imgur.com/4jYIIHy.png)
-![CRO Editing Tools](https://i.imgur.com/1bghcwx.png)
+![RomFS Editing Tools](https://i.imgur.com/IDVCMfx.png)
+![ExeFS Editing Tools](https://i.imgur.com/Ied0sVV.png)
+![CRO Editing Tools](https://i.imgur.com/lUSGbw5.png)

--- a/pk3DS.Core/Legality/Legal.cs
+++ b/pk3DS.Core/Legality/Legal.cs
@@ -193,9 +193,9 @@ namespace pk3DS.Core
             055, // Pokémon Trainer (Shauna)
             056, // Pokémon Trainer (Tierno)
             057, // Pokémon Trainer (Trevor)
-            077, // Team Flare (Admin)*
+            077, // Team Flare (Admin)
             078, // Team Flare (Admin)
-            079, // Team Flare (Grunt)*
+            079, // Team Flare (Grunt)
             080, // Team Flare (Grunt)
             081, // Team Flare (Lysandre)
             102, // Pokémon Trainer (AZ)
@@ -203,7 +203,6 @@ namespace pk3DS.Core
             104, // Pokémon Trainer (Serena)
             105, // Pokémon Profoessor (Sycamore)
             175, // Team Flare Boss (Lysandre)
-            // * = Female
         };
         public static readonly int[] Model_AO =
         {
@@ -215,10 +214,14 @@ namespace pk3DS.Core
             219, // Pokémon Trainer (Steven)
             221, // Lorekeeper (Zinnia)
             267, // Pokémon Trainer (Zinnia)
-            272, // Pokémon Trainer (Wally)*
-            278, // Pokémon Trainer (Brendan)*
-            279, // Pokémon Trainer (May)*
-            // * = has Mega Pendant/Bracelet
+            272, // Pokémon Trainer (Wally)
+        };
+        public static readonly int[] Ignore_AO =
+        {
+            001, 002, 003, 004, 005, 006, 007, 008, 009, 010, 011, 012, 013, 014, 015, 016, 017, 018, 019, 020, 021, 022, 023, 024, 025, 026, 027, 028, 029, 030, 031, 032, 033, 034, 035, 036, 037,
+            038, 039, 040, 041, 042, 043, 044, 045, 046, 047, 048, 049, 050, 051, 052, 053, 054, 055, 056, 057, 058, 059, 060, 061, 062, 063, 064, 065, 066, 067, 068, 069, 070, 071, 072, 073, 074,
+            075, 076, 077, 078, 079, 080, 081, 082, 083, 084, 085, 086, 087, 088, 089, 090, 091, 092, 093, 094, 095, 096, 097, 098, 099, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111,
+            112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126
         };
         public static readonly int[] Z_Moves =
         {

--- a/pk3DS.Core/Legality/Legal.cs
+++ b/pk3DS.Core/Legality/Legal.cs
@@ -183,6 +183,74 @@ namespace pk3DS.Core
             185, // Aether Foundation: Faba
         };
 
+        public static readonly int[] SpecialClasses_USUM =
+{
+            030, // Pokémon Trainer: Hau
+            031, // Island Kahuna: Hala
+            038, // Captain: Ilima
+            042, // Trial Guide: Ben
+            044, // Captain: Lana
+            045, // Captain: Mallow
+            049, // Island Kahuna: Olivia
+            051, // Island Kahuna: Hapu
+            071, // Aether President: Lusamine
+            072, // Aether Branch Chief: Faba
+            076, // Team Skull Boss: Guzma
+            078, // Team Skull Admin: Plumeria
+            079, // Pokémon Trainer: Plumeria
+            080, // Elite Four: Kahili
+            081, // Pokémon Trainer: [~ 157]
+            082, // Aether President: Lusamine
+            083, // Pokémon Trainer: Red
+            084, // Pokémon Trainer: Blue
+            085, // Pokémon Trainer: Sina
+            086, // Pokémon Trainer: Dexio
+            088, // Pokémon Trainer: Anabel
+            092, // Pro Wrestler: The Royal
+            093, // Pokémon Trainer: Molayne
+            099, // Pokémon Trainer: Molayne
+            100, // Pokémon Trainer: Hau
+            101, // Pokémon Trainer: Hau
+            102, // Pokémon Trainer: Gladion
+            103, // Pokémon Trainer: Gladion
+            107, // Elite Four: Acerola
+            109, // Elite Four: Hala
+            110, // Elite Four: Olivia
+            111, // Pokémon Professor: Kukui
+            139, // GAME FREAK: Morimoto
+            140, // Pokémon Trainer: Guzma
+            141, // Island Kahuna: Nanu
+            142, // Captain: Sophocles
+            143, // Pokémon Trainer: Ryuki
+            153, // Captain: Mina
+            162, // Aether Foundation: Faba
+            164, // Island Kahuna: Hapu
+            165, // Pokémon Professor: Kukui
+            185, // Aether Foundation: Faba
+            186, // Pokémon Trainer: Sophocles
+            187, // Pokémon Trainer: Giovanni
+            188, // Pokémon Trainer: Kukui
+            189, // Pokémon Trainer: Lillie
+            190, // Pokémon Trainer: Giovanni
+            191, // Elite Four: Molayne
+            192, // Ultra Recon Squad: Soliera
+            193, // Ultra Recon Squad: Dulse
+            194, // Pokémon Trainer: Hau
+            198, // Team Aqua: Archie
+            199, // Team Galactic: Cyrus
+            200, // Team Magma: Maxie
+            201, // Team Plasma: Ghetsis
+            202, // Team Flare: Lysandre
+            204, // Kantonian Gym: Leader
+            205, // GAME FREAK: Iwao
+            206, // Team Rainbow Rocket: Giovanni
+            207, // Pokémon Trainer: Lillie
+            219, // Pokémon Trainer: Guzma
+            220, // Aether President: Lusamine
+            221, // Pokémon Trainer: Hau
+            222, // Pokémon Trainer: Hau
+        };
+
         public static readonly int[] Model_XY =
         {
             018, // Team Flare (Aliana)

--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -23,6 +23,7 @@ namespace pk3DS
             Array.Resize(ref specieslist, Main.Config.MaxSpeciesID + 1);
             MegaDictionary = GiftEditor6.GetMegaDictionary(Main.Config);
             rModelRestricted = Main.Config.ORAS ? Legal.Model_AO : Legal.Model_XY;
+            rXYBlacklist = Legal.Ignore_AO;
 
             InitializeComponent();
             // String Fetching
@@ -533,6 +534,7 @@ namespace pk3DS
         public static int rDMGCount, rSTABCount;
         private int[] mEvoTypes;
         private static int[] rModelRestricted;
+        private static int[] rXYBlacklist;
         private string[] rImportant;
         private readonly List<string> Tags = new List<string>();
         private readonly Dictionary<string, int> TagTypes = new Dictionary<string, int>();
@@ -726,7 +728,7 @@ namespace pk3DS
                 int randClass() => (int) (rnd32() % rModelRestricted.Length);
                 t.Class = rModelRestricted[randClass()];
             }
-            else 
+            else
             if (
                 rClass // Classes selected to be randomized
                 && (!rOnlySingles || t.BattleType == 0) //  Nonsingles only get changed if rOnlySingles
@@ -738,6 +740,12 @@ namespace pk3DS
                 // Ensure the Random Class isn't an exclusive class
                 while (rIgnoreClass.Contains(rv) || trClass[rv].StartsWith("[~")); // don't allow disallowed classes
                 t.Class = rv;
+
+                if (Main.Config.ORAS && rXYBlacklist.Contains(t.Class)) // Classes 0-126 are leftover from XY and some can crash the game; skip all of them
+                {
+                    for (int i = 127; i <= 279; i++)
+                        t.Class = i;
+                }
             }
         }
         private static void RandomizeTrainerPrizeItem(trdata6 t)

--- a/pk3DS/Subforms/Gen6/TMHMEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/TMHMEditor6.Designer.cs
@@ -34,6 +34,7 @@
             this.L_HM = new System.Windows.Forms.Label();
             this.B_RTM = new System.Windows.Forms.Button();
             this.CHK_RandomizeHM = new System.Windows.Forms.CheckBox();
+            this.CHK_RandomizeField = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.dgvTM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvHM)).BeginInit();
             this.SuspendLayout();
@@ -72,7 +73,7 @@
             this.dgvHM.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvHM.Location = new System.Drawing.Point(256, 25);
             this.dgvHM.Name = "dgvHM";
-            this.dgvHM.Size = new System.Drawing.Size(240, 277);
+            this.dgvHM.Size = new System.Drawing.Size(240, 265);
             this.dgvHM.TabIndex = 3;
             // 
             // L_HM
@@ -97,18 +98,29 @@
             // CHK_RandomizeHM
             // 
             this.CHK_RandomizeHM.AutoSize = true;
-            this.CHK_RandomizeHM.Location = new System.Drawing.Point(256, 308);
+            this.CHK_RandomizeHM.Location = new System.Drawing.Point(256, 294);
             this.CHK_RandomizeHM.Name = "CHK_RandomizeHM";
             this.CHK_RandomizeHM.Size = new System.Drawing.Size(104, 17);
             this.CHK_RandomizeHM.TabIndex = 280;
             this.CHK_RandomizeHM.Text = "Randomize HMs";
             this.CHK_RandomizeHM.UseVisualStyleBackColor = true;
             // 
+            // CHK_RandomizeField
+            // 
+            this.CHK_RandomizeField.AutoSize = true;
+            this.CHK_RandomizeField.Location = new System.Drawing.Point(256, 311);
+            this.CHK_RandomizeField.Name = "CHK_RandomizeField";
+            this.CHK_RandomizeField.Size = new System.Drawing.Size(139, 17);
+            this.CHK_RandomizeField.TabIndex = 281;
+            this.CHK_RandomizeField.Text = "Randomize Field Moves";
+            this.CHK_RandomizeField.UseVisualStyleBackColor = true;
+            // 
             // TMHMEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(504, 332);
+            this.Controls.Add(this.CHK_RandomizeField);
             this.Controls.Add(this.CHK_RandomizeHM);
             this.Controls.Add(this.B_RTM);
             this.Controls.Add(this.L_HM);
@@ -137,5 +149,6 @@
         private System.Windows.Forms.Label L_HM;
         private System.Windows.Forms.Button B_RTM;
         private System.Windows.Forms.CheckBox CHK_RandomizeHM;
+        private System.Windows.Forms.CheckBox CHK_RandomizeField;
     }
 }

--- a/pk3DS/Subforms/Gen6/TMHMEditor6.cs
+++ b/pk3DS/Subforms/Gen6/TMHMEditor6.cs
@@ -157,22 +157,30 @@ namespace pk3DS
         private void B_RandomTM_Click(object sender, EventArgs e)
         {
             if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Randomize TMs?", "Move compatibility will be the same as the base TMs.") != DialogResult.Yes) return;
-            if(CHK_RandomizeHM.Checked)
+            if (CHK_RandomizeHM.Checked)
                 if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Randomizing HMs can halt story progression!", "Continue anyway?") != DialogResult.Yes) return;
 
             int[] randomMoves = Enumerable.Range(1, movelist.Length - 1).Select(i => i).ToArray();
             Util.Shuffle(randomMoves);
 
-            int[] banned = { 15, 19, 57, 70, 127, 249, 291, 148, 290 }; // Moves with overworld effects
+            int[] hm_xy = { 15, 19, 57, 70, 127 }; // Cut, Fly, Surf, Strength, Waterfall
+            int[] hm_oras = { 15, 19, 57, 70, 127, 249, 291 }; // + Rock Smash, Dive
+            int[] field = { 148, 249, 290 }; // Flash (TM70), Rock Smash (XY TM94), Secret Power (ORAS TM94)
             int ctr = 0;
 
             for (int i = 0; i < dgvTM.Rows.Count; i++)
             {
                 int val = Array.IndexOf(movelist, dgvTM.Rows[i].Cells[1].Value);
-                if (banned.Contains(val)) continue;
-                while (banned.Contains(randomMoves[ctr])) ctr++;
 
-                dgvTM.Rows[i].Cells[1].Value = movelist[randomMoves[ctr++]];
+                if (CHK_RandomizeField.Checked)
+                    dgvTM.Rows[i].Cells[1].Value = movelist[randomMoves[ctr++]]; // randomize everything
+
+                else
+                {
+                    if (hm_xy.Contains(val) || hm_oras.Contains(val) || field.Contains(val)) continue; // skip HMs and Field Moves
+                    while (hm_xy.Contains(randomMoves[ctr]) || hm_oras.Contains(randomMoves[ctr]) || field.Contains(randomMoves[ctr])) ctr++;
+                    dgvTM.Rows[i].Cells[1].Value = movelist[randomMoves[ctr++]];
+                }
             }
 
             if (CHK_RandomizeHM.Checked)

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -18,6 +18,7 @@ namespace pk3DS
         private readonly LearnsetRandomizer learn = new LearnsetRandomizer(Main.Config, Main.Config.Learnsets);
         private readonly trdata7[] Trainers;
         private string[][] AltForms;
+        private static int[] TrainerClasses_7;
         private int index = -1;
         private PictureBox[] pba;
 
@@ -52,6 +53,8 @@ namespace pk3DS
 
             CB_TrainerID.SelectedIndex = 0;
             CB_Moves.SelectedIndex = 0;
+
+            TrainerClasses_7 = Main.Config.USUM ? Legal.SpecialClasses_USUM : Legal.SpecialClasses_SM;
         }
 
         private int GetSlot(object sender)
@@ -617,8 +620,11 @@ namespace pk3DS
                     do
                     {
                         rv = (int) (Util.rnd32()%CB_Trainer_Class.Items.Count);
-                    } while (/*trClass[rv].StartsWith("[~") || */Legal.SpecialClasses_SM.Contains(rv) && !CHK_IgnoreSpecialClass.Checked);
-                    // don't allow disallowed classes
+                    } while (/*trClass[rv].StartsWith("[~") || */TrainerClasses_7.Contains(rv) && CHK_IgnoreSpecialClass.Checked); // don't allow disallowed classes
+
+                    if (Main.Config.USUM && rv == 082) // Mother Beast Lusamine; unused in USUM and can crash game
+                        continue;
+
                     tr.TrainerClass = (byte) rv;
                 }
 


### PR DESCRIPTION
Resolves my issue in #251.

Removed some useless/redundant model entries as well. If there's any better implementation lemme know, though this works fine.

Edit (12.09.2017):
Commit 2 adds some TM/HM randomizer options.
- Separate HMs/Field Moves into separate arrays (game-specific)
- Add option to randomize Field Moves (separate from HMs)

Edit (12.10.2017):
Commit 4 resolves #248 (if more Trainer Classes are discovered to crash, they can be added).
- Add USUM Special Trainer Classes (same as SM, with some new additions)
- Blacklist Mother Beast Lusamine in USUM (can crash)