### PR TITLE
Revise Lusamine 2 blacklist

### DIFF
--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -624,7 +624,7 @@ namespace pk3DS
                         rv = (int) (Util.rnd32()%CB_Trainer_Class.Items.Count);
                     } while (/*trClass[rv].StartsWith("[~") || */TrainerClasses_7.Contains(rv) && CHK_IgnoreSpecialClass.Checked); // don't allow disallowed classes
 
-                    if (Main.Config.USUM && rv == 082) // Mother Beast Lusamine; unused in USUM and can crash game
+                    if (rv == 082) // Lusamine 2 (Aether President - 082) can crash Multi Battles, skip
                         continue;
 
                     tr.TrainerClass = (byte) rv;


### PR DESCRIPTION
Just checked in-game, that Trainer Class can mess up Multi Battles in SM as well. Best to just blacklist it entirely since we can't really differentiate Single/Multi battles without AI.