### PR TITLE
Various updates

### DIFF
--- a/pk3DS.Core/Legality/Legal.cs
+++ b/pk3DS.Core/Legality/Legal.cs
@@ -66,41 +66,6 @@ namespace pk3DS.Core
         public static readonly int[] SpecialClasses_ORAS =
         {
             #region Classes
-            000, // Pokémon Trainer
-            001, // Pokémon Trainer
-            004, // Leader
-            035, // Elite Four
-            036, // Elite Four
-            037, // Elite Four
-            038, // Elite Four
-            039, // Leader
-            040, // Leader
-            041, // Leader
-            042, // Leader
-            043, // Leader
-            044, // Leader
-            045, // Leader
-            053, // Champion
-            055, // Pokémon Trainer
-            056, // Pokémon Trainer
-            057, // Pokémon Trainer
-            064, // Battle Chatelaine
-            065, // Battle Chatelaine
-            066, // Battle Chatelaine
-            067, // Battle Chatelaine
-            081, // Team Flare Boss
-            102, // Pokémon Trainer
-            103, // Pokémon Trainer
-            104, // Pokémon Trainer
-            105, // Pokémon Professor
-            109, // Pokémon Trainer
-            110, // Pokémon Trainer
-            119, // Pokémon Trainer
-            120, // Pokémon Trainer
-            121, // Pokémon Trainer
-            124, // Team Flare Boss
-            125, // Successor
-            126, // Leader
             127, // Pokémon Trainer
             128, // Pokémon Trainer
             174, // Aqua Leader
@@ -137,7 +102,6 @@ namespace pk3DS.Core
             279, // Pokémon Trainer
             #endregion
         };
-
         public static readonly int[] SpecialClasses_SM =
         {
             030, // Pokémon Trainer: Hau
@@ -184,7 +148,7 @@ namespace pk3DS.Core
         };
 
         public static readonly int[] SpecialClasses_USUM =
-{
+        {
             030, // Pokémon Trainer: Hau
             031, // Island Kahuna: Hala
             038, // Captain: Ilima
@@ -250,7 +214,6 @@ namespace pk3DS.Core
             221, // Pokémon Trainer: Hau
             222, // Pokémon Trainer: Hau
         };
-
         public static readonly int[] Model_XY =
         {
             018, // Team Flare (Aliana)
@@ -281,7 +244,6 @@ namespace pk3DS.Core
             192, // Pokémon Trainer (Wally)
             219, // Pokémon Trainer (Steven)
             221, // Lorekeeper (Zinnia)
-            267, // Pokémon Trainer (Zinnia)
             272, // Pokémon Trainer (Wally)
         };
         public static readonly int[] TrainerClasses_AO =
@@ -306,7 +268,6 @@ namespace pk3DS.Core
             217, 218, 219, 220, 221, 222, 235, 236, 238, 239, 240, 241, 349, 350, 351, 352, 356, 357, 358, 359, 360, 371, 372, 392, 396, 398, 400, 401, 403, 405, 409, 410, 413, 414, 415, 416, 417,
             418, 419, 435, 438, 439, 440, 441, 447, 448, 449, 450, 451, 452, 467, 477, 478, 479, 481, 482, 483, 484,
         };
-
         public static readonly int[] ImportantTrainers_USUM =
         {
             012, 013, 014, 023, 052, 076, 077, 078, 079, 081, 082, 083, 084, 089, 090, 131, 132, 138, 144, 146, 149, 153, 154, 156, 159, 160, 185, 215, 216, 217, 218, 219, 220, 221, 222, 235, 236,
@@ -314,7 +275,10 @@ namespace pk3DS.Core
             490, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 541, 542, 543, 555, 556, 557, 558, 559, 560, 561, 562, 572, 573, 578, 580, 582, 583, 630, 644, 645, 647,
             648, 649, 650, 651, 652,
         };
-
+        /// <summary>
+        /// All final evolutions, excluding Event-exclusive Forms that do not evolve (Pikachu, Floette, etc). Used for forcing fully evolved species.
+        /// Overrides all other randomizer settings, allowing all Generations and Legendary/Mythical Pokemon as well.
+        /// </summary>
         public static readonly int[] FinalEvolutions_6 =
         {
             003, 006, 009, 012, 015, 018, 020, 022, 024, 026, 028, 028, 031, 034, 036, 038, 040, 045, 047, 049, 051, 053, 055, 057, 059, 062, 065, 068, 071, 073, 076, 078, 080, 083, 085, 087, 089,
@@ -329,13 +293,11 @@ namespace pk3DS.Core
             635, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 652, 655, 658, 660, 663, 666, 668, 671, 673, 675, 676, 678, 681, 683, 685, 687, 689, 691, 693, 695, 697, 699, 700,
             701, 702, 703, 706, 707, 709, 711, 713, 715, 716, 717, 718,
         };
-
         public static readonly int[] FinalEvolutions_SM = FinalEvolutions_6.Concat(new int[]
         {
             724, 727, 730, 733, 735, 738, 740, 741, 743, 745, 746, 748, 750, 752, 754, 756, 758, 760, 763, 764, 765, 766, 768, 770, 771,
             773, 774, 775, 776, 777, 779, 780, 781, 784, 785, 786, 787, 788, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802,
         }).ToArray();
-
         public static readonly int[] FinalEvolutions_USUM = FinalEvolutions_SM.Concat(new int[]
         {
             804, 805, 806, 807,

--- a/pk3DS.Core/Randomizers/SpeciesRandomizer.cs
+++ b/pk3DS.Core/Randomizers/SpeciesRandomizer.cs
@@ -164,33 +164,33 @@ namespace pk3DS.Core.Randomizers
         }
         private void AddGen3Species(List<int> list)
         {
-            list.AddRange(Enumerable.Range(252, 40));
-            list.AddRange(Enumerable.Range(293, 84));
+            list.AddRange(Enumerable.Range(252, 40)); // Treecko - Ninjask
+            list.AddRange(Enumerable.Range(293, 84)); // Whismur - Metagross
             if (Shedinja) list.Add(292); // Shedinja
             if (L) list.AddRange(Enumerable.Range(377, 8)); // Regi, Lati, Mascot
             if (E) list.AddRange(Enumerable.Range(385, 2)); // Jirachi/Deoxys
         }
         private void AddGen4Species(List<int> list)
         {
-            list.AddRange(Enumerable.Range(387, 93));
+            list.AddRange(Enumerable.Range(387, 93)); // Turtwig - Rotom
             if (L) list.AddRange(Enumerable.Range(480, 9)); // Sinnoh Legends
             if (E) list.AddRange(Enumerable.Range(489, 5)); // Phione, Manaphy, Darkrai, Shaymin, Arceus
         }
         private void AddGen5Species(List<int> list)
         {
-            list.AddRange(Enumerable.Range(495, 143));
-            if (L) list.AddRange(Enumerable.Range(638, 9)); list.Add(494); // Unova Legends
-            if (E) list.AddRange(Enumerable.Range(647, 3)); // Keldeo, Meloetta, Genesect
+            list.AddRange(Enumerable.Range(495, 143)); // Snivy - Volcarona
+            if (L) list.AddRange(Enumerable.Range(638, 9)); // Unova Legends
+            if (E) list.Add(494); list.AddRange(Enumerable.Range(647, 3)); // Victini, Keldeo, Meloetta, Genesect
         }
         private void AddGen6Species(List<int> list)
         {
-            list.AddRange(Enumerable.Range(650, 66));
+            list.AddRange(Enumerable.Range(650, 66)); // Chespin - Noivern
             if (L) list.AddRange(Enumerable.Range(716, 3)); // Kalos Legends
             if (E) list.AddRange(Enumerable.Range(719, 3)); // Diancie, Hoopa, Volcanion
         }
         private void AddGen7Species(List<int> list)
         {
-            list.AddRange(Enumerable.Range(722, 67));
+            list.AddRange(Enumerable.Range(722, 67)); // Rowlet - Kommo-o
             if (L) list.AddRange(Enumerable.Range(785, 16)); // Tapus, Legends, UBs
             if (E) list.AddRange(Enumerable.Range(801, 2)); // Magearna, Marshadow
 

--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -599,14 +599,21 @@ namespace pk3DS
                     case 6:
                         files = new[] { "encdata" };
                         if (Config.ORAS)
+                        {
+                            Enabled = false;
                             action = () => new RSWE().ShowDialog();
+                        }
                         else if (Config.XY)
+                        {
+                            Enabled = false;
                             action = () => new XYWE().ShowDialog();
+                        }
                         else return;
 
                         fileGet(files, false);
                         Invoke(action);
                         fileSet(files);
+                        Enabled = true;
                         break;
                     case 7:
                         Invoke((MethodInvoker)delegate { Enabled = false; });

--- a/pk3DS/Subforms/Gen6/GiftEditor6.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.cs
@@ -319,8 +319,6 @@ namespace pk3DS
             {475, new[] {756}}, // Gallade @ Galladite
             {531, new[] {757}}, // Audino @ Audinite
             {719, new[] {764}}, // Diancie @ Diancite
-
-            {384, new[] {-620}}, // Rayquaza @ Dragon Ascent
         };
         private void changeSpecies(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -521,7 +521,7 @@ namespace pk3DS
             readFile();
         }
 
-        public static bool rPKM, rSmart, rLevel, rMove, rNoMove, rAbility, rDiffAI, 
+        public static bool rPKM, rSmart, rLevel, rMove, rNoMove, rHighPower, rAbility, rDiffAI, 
             rDiffIV, rClass, rGift, rItem, rDoRand, rRandomMegas, rGymE4Only,
             rTypeTheme, rTypeGymTrainers, rOnlySingles, rDMG, rSTAB, r6PKM, rForceFullyEvolved;
         public static bool rNoFixedDamage;
@@ -686,6 +686,13 @@ namespace pk3DS
                 else if (rItem)
                     pk.Item = itemvals[rnd32() % itemvals.Length];
 
+                if (rForceFullyEvolved && pk.Level >= rForceFullyEvolvedLevel && !rFinalEvo.Contains(pk.Species))
+                {
+                    int randFinalEvo() => (int)(Util.rnd32() % rFinalEvo.Length);
+                    pk.Species = (ushort)rFinalEvo[randFinalEvo()];
+                    pk.Form = (ushort)Randomizer.GetRandomForme(pk.Species, rRandomMegas, true, Main.SpeciesStat);
+                }
+
                 // random
                 if (rMove)
                 {
@@ -703,14 +710,12 @@ namespace pk3DS
                         pk.Moves[m] = (ushort)pkMoves[m];
                 }
 
-                if (rForceFullyEvolved && pk.Level >= rForceFullyEvolvedLevel)
+                // high-power attacks
+                if (rHighPower)
                 {
-                    if (!rFinalEvo.Contains(pk.Species))
-                    {
-                        int randFinalEvo() => (int)(Util.rnd32() % rFinalEvo.Length);
-                        pk.Species = (ushort)rFinalEvo[randFinalEvo()];
-                        pk.Form = (ushort)Randomizer.GetRandomForme(pk.Species, rRandomMegas, true, Main.SpeciesStat);
-                    }
+                    var pkMoves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
+                    for (int m = 0; m < 4; m++)
+                        pk.Moves[m] = (ushort)pkMoves[m];
                 }
             }
         }

--- a/pk3DS/Subforms/Gen6/RSWE.Designer.cs
+++ b/pk3DS/Subforms/Gen6/RSWE.Designer.cs
@@ -26218,6 +26218,7 @@
             this.MinimumSize = new System.Drawing.Size(964, 454);
             this.Name = "RSWE";
             this.Text = "ORAS Wild Editor";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.RSWE_FormClosing);
             this.TabPage_Horde.ResumeLayout(false);
             this.TabPage_Horde.PerformLayout();
             this.GB_Tweak.ResumeLayout(false);

--- a/pk3DS/Subforms/Gen6/RSWE.cs
+++ b/pk3DS/Subforms/Gen6/RSWE.cs
@@ -803,5 +803,10 @@ namespace pk3DS
             Enabled = true;
             WinFormsUtil.Alert("Modified all Level ranges according to specification!", "Press the Dump Tables button to view the new Level ranges!");
         }
+
+        private void RSWE_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            RandSettings.SetFormSettings(this, GB_Tweak.Controls);
+        }
     }
 }

--- a/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
@@ -42,11 +42,12 @@
             this.NUD_Level = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
             this.GB_Tweak = new System.Windows.Forms.GroupBox();
+            this.NUD_ForceFullyEvolved = new System.Windows.Forms.NumericUpDown();
             this.CHK_GymE4Only = new System.Windows.Forms.CheckBox();
-            this.CHK_RandomMegaForm = new System.Windows.Forms.CheckBox();
-            this.CHK_6PKM = new System.Windows.Forms.CheckBox();
+            this.CHK_ForceFullyEvolved = new System.Windows.Forms.CheckBox();
             this.CHK_GymTrainers = new System.Windows.Forms.CheckBox();
             this.CHK_StoryMEvos = new System.Windows.Forms.CheckBox();
+            this.CHK_RandomMegaForm = new System.Windows.Forms.CheckBox();
             this.CHK_TypeTheme = new System.Windows.Forms.CheckBox();
             this.CHK_BST = new System.Windows.Forms.CheckBox();
             this.CHK_E = new System.Windows.Forms.CheckBox();
@@ -57,6 +58,7 @@
             this.CHK_G3 = new System.Windows.Forms.CheckBox();
             this.CHK_G2 = new System.Windows.Forms.CheckBox();
             this.CHK_G1 = new System.Windows.Forms.CheckBox();
+            this.CHK_6PKM = new System.Windows.Forms.CheckBox();
             this.CHK_IgnoreSpecialClass = new System.Windows.Forms.CheckBox();
             this.CHK_OnlySingles = new System.Windows.Forms.CheckBox();
             this.NUD_Damage = new System.Windows.Forms.NumericUpDown();
@@ -66,14 +68,12 @@
             this.CB_Moves = new System.Windows.Forms.ComboBox();
             this.L_Moves = new System.Windows.Forms.Label();
             this.CHK_NoFixedDamage = new System.Windows.Forms.CheckBox();
-            this.NUD_Force = new System.Windows.Forms.NumericUpDown();
-            this.CHK_ForceFullyEvolved = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GiftPercent)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Level)).BeginInit();
             this.GB_Tweak.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Damage)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_STAB)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_Force)).BeginInit();
             this.SuspendLayout();
             // 
             // CHK_RandomPKM
@@ -260,7 +260,7 @@
             // 
             this.GB_Tweak.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.GB_Tweak.Controls.Add(this.NUD_Force);
+            this.GB_Tweak.Controls.Add(this.NUD_ForceFullyEvolved);
             this.GB_Tweak.Controls.Add(this.CHK_GymE4Only);
             this.GB_Tweak.Controls.Add(this.CHK_ForceFullyEvolved);
             this.GB_Tweak.Controls.Add(this.CHK_GymTrainers);
@@ -283,6 +283,19 @@
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Options";
             // 
+            // NUD_ForceFullyEvolved
+            // 
+            this.NUD_ForceFullyEvolved.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(168, 97);
+            this.NUD_ForceFullyEvolved.Name = "NUD_ForceFullyEvolved";
+            this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(43, 20);
+            this.NUD_ForceFullyEvolved.TabIndex = 334;
+            this.NUD_ForceFullyEvolved.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            // 
             // CHK_GymE4Only
             // 
             this.CHK_GymE4Only.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
@@ -295,28 +308,16 @@
             this.CHK_GymE4Only.Text = "Theme Gym/E4 Only";
             this.CHK_GymE4Only.UseVisualStyleBackColor = true;
             // 
-            // CHK_RandomMegaForm
+            // CHK_ForceFullyEvolved
             // 
-            this.CHK_RandomMegaForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.CHK_RandomMegaForm.AutoSize = true;
-            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(9, 81);
-            this.CHK_RandomMegaForm.Name = "CHK_RandomMegaForm";
-            this.CHK_RandomMegaForm.Size = new System.Drawing.Size(127, 17);
-            this.CHK_RandomMegaForm.TabIndex = 294;
-            this.CHK_RandomMegaForm.Text = "Random Mega Forms";
-            this.CHK_RandomMegaForm.UseVisualStyleBackColor = true;
-            // 
-            // CHK_6PKM
-            // 
-            this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.CHK_6PKM.AutoSize = true;
-            this.CHK_6PKM.Location = new System.Drawing.Point(21, 215);
-            this.CHK_6PKM.Name = "CHK_6PKM";
-            this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
-            this.CHK_6PKM.TabIndex = 293;
-            this.CHK_6PKM.Text = "6 Pokémon for Important Trainers";
-            this.CHK_6PKM.UseVisualStyleBackColor = true;
-            this.CHK_6PKM.CheckedChanged += new System.EventHandler(this.CHK_6PKM_CheckedChanged);
+            this.CHK_ForceFullyEvolved.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.CHK_ForceFullyEvolved.AutoSize = true;
+            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(9, 99);
+            this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
+            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
+            this.CHK_ForceFullyEvolved.TabIndex = 333;
+            this.CHK_ForceFullyEvolved.Text = "Force Fully Evolved at Level";
+            this.CHK_ForceFullyEvolved.UseVisualStyleBackColor = true;
             // 
             // CHK_GymTrainers
             // 
@@ -342,6 +343,17 @@
             this.CHK_StoryMEvos.TabIndex = 291;
             this.CHK_StoryMEvos.Text = "Ensure Story Mega Evolutions";
             this.CHK_StoryMEvos.UseVisualStyleBackColor = true;
+            // 
+            // CHK_RandomMegaForm
+            // 
+            this.CHK_RandomMegaForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.CHK_RandomMegaForm.AutoSize = true;
+            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(9, 81);
+            this.CHK_RandomMegaForm.Name = "CHK_RandomMegaForm";
+            this.CHK_RandomMegaForm.Size = new System.Drawing.Size(127, 17);
+            this.CHK_RandomMegaForm.TabIndex = 294;
+            this.CHK_RandomMegaForm.Text = "Random Mega Forms";
+            this.CHK_RandomMegaForm.UseVisualStyleBackColor = true;
             // 
             // CHK_TypeTheme
             // 
@@ -461,6 +473,18 @@
             this.CHK_G1.Text = "Gen 1";
             this.CHK_G1.UseVisualStyleBackColor = true;
             // 
+            // CHK_6PKM
+            // 
+            this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.CHK_6PKM.AutoSize = true;
+            this.CHK_6PKM.Location = new System.Drawing.Point(21, 215);
+            this.CHK_6PKM.Name = "CHK_6PKM";
+            this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
+            this.CHK_6PKM.TabIndex = 293;
+            this.CHK_6PKM.Text = "6 Pokémon for Important Trainers";
+            this.CHK_6PKM.UseVisualStyleBackColor = true;
+            this.CHK_6PKM.CheckedChanged += new System.EventHandler(this.CHK_6PKM_CheckedChanged);
+            // 
             // CHK_IgnoreSpecialClass
             // 
             this.CHK_IgnoreSpecialClass.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
@@ -557,10 +581,11 @@
             this.CB_Moves.Items.AddRange(new object[] {
             "Don\'t Modify",
             "Randomize All",
-            "Use Levelup Only"});
+            "Use Levelup Only",
+            "High Powered Attacks"});
             this.CB_Moves.Location = new System.Drawing.Point(67, 251);
             this.CB_Moves.Name = "CB_Moves";
-            this.CB_Moves.Size = new System.Drawing.Size(121, 21);
+            this.CB_Moves.Size = new System.Drawing.Size(135, 21);
             this.CB_Moves.TabIndex = 330;
             this.CB_Moves.SelectedIndexChanged += new System.EventHandler(this.changeMoveRandomization);
             // 
@@ -585,30 +610,6 @@
             this.CHK_NoFixedDamage.TabIndex = 332;
             this.CHK_NoFixedDamage.Text = "No Fixed Damage Moves (Dragon Rage/Sonic Boom)";
             this.CHK_NoFixedDamage.UseVisualStyleBackColor = true;
-            // 
-            // NUD_Force
-            // 
-            this.NUD_Force.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_Force.Location = new System.Drawing.Point(169, 98);
-            this.NUD_Force.Name = "NUD_Force";
-            this.NUD_Force.Size = new System.Drawing.Size(43, 20);
-            this.NUD_Force.TabIndex = 334;
-            this.NUD_Force.Value = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            // 
-            // CHK_ForceFullyEvolved
-            // 
-            this.CHK_ForceFullyEvolved.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.CHK_ForceFullyEvolved.AutoSize = true;
-            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(9, 99);
-            this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
-            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
-            this.CHK_ForceFullyEvolved.TabIndex = 333;
-            this.CHK_ForceFullyEvolved.Text = "Force Fully Evolved at Level";
-            this.CHK_ForceFullyEvolved.UseVisualStyleBackColor = true;
             // 
             // TrainerRand
             // 
@@ -650,9 +651,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Level)).EndInit();
             this.GB_Tweak.ResumeLayout(false);
             this.GB_Tweak.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Damage)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_STAB)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_Force)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -698,7 +699,7 @@
         private System.Windows.Forms.CheckBox CHK_RandomMegaForm;
         private System.Windows.Forms.CheckBox CHK_GymE4Only;
         private System.Windows.Forms.CheckBox CHK_NoFixedDamage;
-        private System.Windows.Forms.NumericUpDown NUD_Force;
+        private System.Windows.Forms.NumericUpDown NUD_ForceFullyEvolved;
         private System.Windows.Forms.CheckBox CHK_ForceFullyEvolved;
     }
 }

--- a/pk3DS/Subforms/Gen6/TrainerRand.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.cs
@@ -41,6 +41,7 @@ namespace pk3DS
 
             RSTE.rMove = CB_Moves.SelectedIndex == 1;
             RSTE.rNoMove = CB_Moves.SelectedIndex == 2;
+            RSTE.rHighPower = CB_Moves.SelectedIndex == 3;
             if (RSTE.rMove)
             {
                 RSTE.rDMG = CHK_Damage.Checked;
@@ -73,7 +74,7 @@ namespace pk3DS
             RSTE.r6PKM = CHK_6PKM.Checked;
             RSTE.rRandomMegas = CHK_RandomMegaForm.Checked;
             RSTE.rForceFullyEvolved = CHK_ForceFullyEvolved.Checked;
-            RSTE.rForceFullyEvolvedLevel = NUD_Force.Value;
+            RSTE.rForceFullyEvolvedLevel = NUD_ForceFullyEvolved.Value;
 
             if (CHK_StoryMEvos.Checked)
             {

--- a/pk3DS/Subforms/Gen7/SMTE.Designer.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.Designer.cs
@@ -180,6 +180,7 @@
             this.CHK_RandomItems = new System.Windows.Forms.CheckBox();
             this.CHK_STAB = new System.Windows.Forms.CheckBox();
             this.Tab_Trainer1 = new System.Windows.Forms.TabPage();
+            this.CHK_6PKM = new System.Windows.Forms.CheckBox();
             this.NUD_ForceFullyEvolved = new System.Windows.Forms.NumericUpDown();
             this.CHK_ForceFullyEvolved = new System.Windows.Forms.CheckBox();
             this.L_MinPKM = new System.Windows.Forms.Label();
@@ -190,7 +191,6 @@
             this.CHK_TypeTheme = new System.Windows.Forms.CheckBox();
             this.CHK_IgnoreSpecialClass = new System.Windows.Forms.CheckBox();
             this.CHK_RandomClass = new System.Windows.Forms.CheckBox();
-            this.CHK_6PKM = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Team1)).BeginInit();
             this.mnuVSD.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Team2)).BeginInit();
@@ -1874,7 +1874,7 @@
             "High Powered Attacks"});
             this.CB_Moves.Location = new System.Drawing.Point(52, 8);
             this.CB_Moves.Name = "CB_Moves";
-            this.CB_Moves.Size = new System.Drawing.Size(121, 21);
+            this.CB_Moves.Size = new System.Drawing.Size(135, 21);
             this.CB_Moves.TabIndex = 337;
             this.CB_Moves.SelectedIndexChanged += new System.EventHandler(this.CB_Moves_SelectedIndexChanged);
             // 
@@ -2000,6 +2000,17 @@
             this.Tab_Trainer1.TabIndex = 2;
             this.Tab_Trainer1.Text = "Trainer";
             this.Tab_Trainer1.UseVisualStyleBackColor = true;
+            // 
+            // CHK_6PKM
+            // 
+            this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.CHK_6PKM.AutoSize = true;
+            this.CHK_6PKM.Location = new System.Drawing.Point(6, 94);
+            this.CHK_6PKM.Name = "CHK_6PKM";
+            this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
+            this.CHK_6PKM.TabIndex = 341;
+            this.CHK_6PKM.Text = "6 Pokémon for Important Trainers";
+            this.CHK_6PKM.UseVisualStyleBackColor = true;
             // 
             // NUD_ForceFullyEvolved
             // 
@@ -2141,17 +2152,6 @@
             this.CHK_RandomClass.Text = "Random Trainer Classes";
             this.CHK_RandomClass.UseVisualStyleBackColor = true;
             this.CHK_RandomClass.CheckedChanged += new System.EventHandler(this.CHK_RandomClass_CheckedChanged);
-            // 
-            // CHK_6PKM
-            // 
-            this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.CHK_6PKM.AutoSize = true;
-            this.CHK_6PKM.Location = new System.Drawing.Point(6, 94);
-            this.CHK_6PKM.Name = "CHK_6PKM";
-            this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
-            this.CHK_6PKM.TabIndex = 341;
-            this.CHK_6PKM.Text = "6 Pokémon for Important Trainers";
-            this.CHK_6PKM.UseVisualStyleBackColor = true;
             // 
             // SMTE
             // 

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -230,8 +230,7 @@ namespace pk3DS
             CB_HPType.SelectedIndex = 0;
 
             CB_Nature.Items.Clear();
-            foreach (string s in natures)
-                CB_Nature.Items.Add(s);
+            CB_Nature.Items.AddRange(natures.Take(25).ToArray());
 
             CB_Item.Items.Clear();
             foreach (string s in itemlist)
@@ -671,10 +670,11 @@ namespace pk3DS
                 {
                     if (CHK_RandomPKM.Checked)
                     {
-                        int Type = CHK_TypeTheme.Checked ? (int)Util.rnd32()%17 : -1;
+                        int Type = CHK_TypeTheme.Checked ? (int)Util.rnd32() % 17 : -1;
                         pk.Species = rnd.GetRandomSpeciesType(pk.Species, Type);
                         pk.Form = Randomizer.GetRandomForme(pk.Species, CHK_RandomMegaForm.Checked, true, Main.SpeciesStat);
-                        pk.Gender = 0; // Random Gender
+                        pk.Gender = 0; // random
+                        pk.Nature = (int)(Util.rnd32() % CB_Nature.Items.Count); // random
                     }
                     if (CHK_Level.Checked)
                         pk.Level = Randomizer.getModifiedLevel(pk.Level, NUD_LevelBoost.Value);
@@ -686,15 +686,12 @@ namespace pk3DS
                         pk.Ability = (int)Util.rnd32()%4;
                     if (CHK_MaxDiffPKM.Checked)
                         pk.IVs = new[] {31, 31, 31, 31, 31, 31};
-
-                    if (CHK_ForceFullyEvolved.Checked && pk.Level >= NUD_ForceFullyEvolved.Value)
+                    
+                    if (CHK_ForceFullyEvolved.Checked && pk.Level >= NUD_ForceFullyEvolved.Value && !FinalEvo.Contains(pk.Species))
                     {
-                        if (!FinalEvo.Contains(pk.Species))
-                        {
-                            int randFinalEvo() => (int)(Util.rnd32() % FinalEvo.Length);
-                            pk.Species = FinalEvo[randFinalEvo()];
-                            pk.Form = Randomizer.GetRandomForme(pk.Species, CHK_RandomMegaForm.Checked, true, Main.SpeciesStat);
-                        }
+                        int randFinalEvo() => (int)(Util.rnd32() % FinalEvo.Length);
+                        pk.Species = FinalEvo[randFinalEvo()];
+                        pk.Form = Randomizer.GetRandomForme(pk.Species, CHK_RandomMegaForm.Checked, true, Main.SpeciesStat);
                     }
 
                     switch (CB_Moves.SelectedIndex)

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -481,7 +481,7 @@ namespace pk3DS
                     t.SpecialMove = Util.rand.Next(1, CB_SpecialMove.Items.Count); // don't allow none
 
                 if (CHK_RandomAbility.Checked)
-                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2 , or H
+                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2, or H
             }
 
             getListBoxEntries();
@@ -526,7 +526,7 @@ namespace pk3DS
                     t.SpecialMove = Util.rand.Next(1, CB_SpecialMove.Items.Count); // don't allow none
 
                 if (CHK_RandomAbility.Checked)
-                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2 , or H
+                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2, or H
             }
             foreach (EncounterStatic7 t in Encounters)
             {
@@ -552,7 +552,7 @@ namespace pk3DS
                     t.Aura = Util.rand.Next(1, CB_Aura.Items.Count); // don't allow none
 
                 if (CHK_RandomAbility.Checked)
-                    t.Ability = (sbyte)(Util.rand.Next(1, 4)); // 1, 2 , or H
+                    t.Ability = (sbyte)(Util.rand.Next(1, 4)); // 1, 2, or H
             }
             foreach (EncounterTrade7 t in Trades)
             {
@@ -571,7 +571,7 @@ namespace pk3DS
                     t.Level = Randomizer.getModifiedLevel(t.Level, NUD_LevelBoost.Value);
 
                 if (CHK_RandomAbility.Checked)
-                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2 , or H
+                    t.Ability = (sbyte)(Util.rand.Next(0, 3)); // 1, 2, or H
             }
 
             getListBoxEntries();


### PR DESCRIPTION
- Remove Rayquaza from Mega Dictionary
Could lead to exceptions with GiftEditor6 due to Moves not being in the data structure
- Simplify Force Fully Evolved to one if-check (RSTE and SMTE)
Also place above Move randomizers in RSTE to fix a bug where Moves would not be overwritten for replaced species
- Fix RSWE RandSettings not saving
- Add High Powered Attacks option for RSTE
- Add Nature randomization for SMTE
- Revise comments in StaticEncounterEditor7
- Add enable/disable functions when opening XYWE/RSWE (akin to SMWE)
This will avoid confusion on when GARC get/set takes place
- Remove XY classes from `SpecialClasses_ORAS`
- Add documentation for `FinalEvolutions_6`
- Update SpeciesRandomizer comments
- Fix Victini in SpeciesRandomizer
Mythical, not Legendary!