### PR TITLE
Enhance high-powered attack modification

### DIFF
--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -521,7 +521,7 @@ namespace pk3DS
             readFile();
         }
 
-        public static bool rPKM, rSmart, rLevel, rMove, rNoMove, rHighPower, rAbility, rDiffAI, 
+        public static bool rPKM, rSmart, rLevel, rMove, rNoMove, rForceHighPower, rAbility, rDiffAI, 
             rDiffIV, rClass, rGift, rItem, rDoRand, rRandomMegas, rGymE4Only,
             rTypeTheme, rTypeGymTrainers, rOnlySingles, rDMG, rSTAB, r6PKM, rForceFullyEvolved;
         public static bool rNoFixedDamage;
@@ -538,7 +538,7 @@ namespace pk3DS
         private readonly List<string> Tags = new List<string>();
         private readonly Dictionary<string, int> TagTypes = new Dictionary<string, int>();
         public static int[] sL; // Random Species List
-        public static decimal rGiftPercent, rLevelMultiplier, rForceFullyEvolvedLevel;
+        public static decimal rGiftPercent, rLevelMultiplier, rForceFullyEvolvedLevel, rForceHighPowerLevel;
         private void B_Randomize_Click(object sender, EventArgs e)
         {
             rPKM = rMove = rAbility = rDiffAI = rDiffIV = rClass = rGift = rItem = rDoRand = false; // init to false
@@ -711,7 +711,7 @@ namespace pk3DS
                 }
 
                 // high-power attacks
-                if (rHighPower)
+                if (rForceHighPower && pk.Level >= rForceHighPowerLevel)
                 {
                     var pkMoves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
                     for (int m = 0; m < 4; m++)

--- a/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
@@ -68,12 +68,15 @@
             this.CB_Moves = new System.Windows.Forms.ComboBox();
             this.L_Moves = new System.Windows.Forms.Label();
             this.CHK_NoFixedDamage = new System.Windows.Forms.CheckBox();
+            this.CHK_ForceHighPower = new System.Windows.Forms.CheckBox();
+            this.NUD_ForceHighPower = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GiftPercent)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Level)).BeginInit();
             this.GB_Tweak.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Damage)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_STAB)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceHighPower)).BeginInit();
             this.SuspendLayout();
             // 
             // CHK_RandomPKM
@@ -95,7 +98,7 @@
             this.CHK_RandomItems.AutoSize = true;
             this.CHK_RandomItems.Checked = true;
             this.CHK_RandomItems.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomItems.Location = new System.Drawing.Point(21, 314);
+            this.CHK_RandomItems.Location = new System.Drawing.Point(21, 324);
             this.CHK_RandomItems.Name = "CHK_RandomItems";
             this.CHK_RandomItems.Size = new System.Drawing.Size(119, 17);
             this.CHK_RandomItems.TabIndex = 6;
@@ -108,7 +111,7 @@
             this.CHK_RandomAbilities.AutoSize = true;
             this.CHK_RandomAbilities.Checked = true;
             this.CHK_RandomAbilities.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomAbilities.Location = new System.Drawing.Point(21, 329);
+            this.CHK_RandomAbilities.Location = new System.Drawing.Point(21, 339);
             this.CHK_RandomAbilities.Name = "CHK_RandomAbilities";
             this.CHK_RandomAbilities.Size = new System.Drawing.Size(193, 17);
             this.CHK_RandomAbilities.TabIndex = 7;
@@ -121,7 +124,7 @@
             this.CHK_RandomGift.AutoSize = true;
             this.CHK_RandomGift.Checked = true;
             this.CHK_RandomGift.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomGift.Location = new System.Drawing.Point(21, 408);
+            this.CHK_RandomGift.Location = new System.Drawing.Point(21, 418);
             this.CHK_RandomGift.Name = "CHK_RandomGift";
             this.CHK_RandomGift.Size = new System.Drawing.Size(145, 17);
             this.CHK_RandomGift.TabIndex = 10;
@@ -135,7 +138,7 @@
             this.CHK_RandomClass.AutoSize = true;
             this.CHK_RandomClass.Checked = true;
             this.CHK_RandomClass.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomClass.Location = new System.Drawing.Point(21, 361);
+            this.CHK_RandomClass.Location = new System.Drawing.Point(21, 371);
             this.CHK_RandomClass.Name = "CHK_RandomClass";
             this.CHK_RandomClass.Size = new System.Drawing.Size(141, 17);
             this.CHK_RandomClass.TabIndex = 9;
@@ -149,7 +152,7 @@
             this.CHK_MaxDiffAI.AutoSize = true;
             this.CHK_MaxDiffAI.Checked = true;
             this.CHK_MaxDiffAI.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_MaxDiffAI.Location = new System.Drawing.Point(21, 423);
+            this.CHK_MaxDiffAI.Location = new System.Drawing.Point(21, 433);
             this.CHK_MaxDiffAI.Name = "CHK_MaxDiffAI";
             this.CHK_MaxDiffAI.Size = new System.Drawing.Size(95, 17);
             this.CHK_MaxDiffAI.TabIndex = 13;
@@ -162,7 +165,7 @@
             this.CHK_MaxDiffPKM.AutoSize = true;
             this.CHK_MaxDiffPKM.Checked = true;
             this.CHK_MaxDiffPKM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_MaxDiffPKM.Location = new System.Drawing.Point(21, 344);
+            this.CHK_MaxDiffPKM.Location = new System.Drawing.Point(21, 354);
             this.CHK_MaxDiffPKM.Name = "CHK_MaxDiffPKM";
             this.CHK_MaxDiffPKM.Size = new System.Drawing.Size(64, 17);
             this.CHK_MaxDiffPKM.TabIndex = 8;
@@ -172,7 +175,7 @@
             // B_OK
             // 
             this.B_OK.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.B_OK.Location = new System.Drawing.Point(250, 385);
+            this.B_OK.Location = new System.Drawing.Point(247, 409);
             this.B_OK.Name = "B_OK";
             this.B_OK.Size = new System.Drawing.Size(50, 23);
             this.B_OK.TabIndex = 14;
@@ -183,7 +186,7 @@
             // B_Cancel
             // 
             this.B_Cancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.B_Cancel.Location = new System.Drawing.Point(250, 407);
+            this.B_Cancel.Location = new System.Drawing.Point(247, 431);
             this.B_Cancel.Name = "B_Cancel";
             this.B_Cancel.Size = new System.Drawing.Size(50, 23);
             this.B_Cancel.TabIndex = 15;
@@ -194,7 +197,7 @@
             // NUD_GiftPercent
             // 
             this.NUD_GiftPercent.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_GiftPercent.Location = new System.Drawing.Point(166, 405);
+            this.NUD_GiftPercent.Location = new System.Drawing.Point(166, 415);
             this.NUD_GiftPercent.Name = "NUD_GiftPercent";
             this.NUD_GiftPercent.Size = new System.Drawing.Size(43, 20);
             this.NUD_GiftPercent.TabIndex = 11;
@@ -209,7 +212,7 @@
             // 
             this.label1.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(211, 407);
+            this.label1.Location = new System.Drawing.Point(211, 417);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(15, 13);
             this.label1.TabIndex = 12;
@@ -278,7 +281,7 @@
             this.GB_Tweak.Controls.Add(this.CHK_G1);
             this.GB_Tweak.Location = new System.Drawing.Point(12, 49);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(270, 163);
+            this.GB_Tweak.Size = new System.Drawing.Size(270, 155);
             this.GB_Tweak.TabIndex = 323;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Options";
@@ -286,7 +289,7 @@
             // NUD_ForceFullyEvolved
             // 
             this.NUD_ForceFullyEvolved.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(168, 97);
+            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(168, 98);
             this.NUD_ForceFullyEvolved.Name = "NUD_ForceFullyEvolved";
             this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(43, 20);
             this.NUD_ForceFullyEvolved.TabIndex = 334;
@@ -301,7 +304,7 @@
             this.CHK_GymE4Only.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_GymE4Only.AutoSize = true;
             this.CHK_GymE4Only.Enabled = false;
-            this.CHK_GymE4Only.Location = new System.Drawing.Point(141, 134);
+            this.CHK_GymE4Only.Location = new System.Drawing.Point(141, 133);
             this.CHK_GymE4Only.Name = "CHK_GymE4Only";
             this.CHK_GymE4Only.Size = new System.Drawing.Size(125, 17);
             this.CHK_GymE4Only.TabIndex = 295;
@@ -312,7 +315,7 @@
             // 
             this.CHK_ForceFullyEvolved.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.CHK_ForceFullyEvolved.AutoSize = true;
-            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(9, 99);
+            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(9, 100);
             this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
             this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
             this.CHK_ForceFullyEvolved.TabIndex = 333;
@@ -324,7 +327,7 @@
             this.CHK_GymTrainers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_GymTrainers.AutoSize = true;
             this.CHK_GymTrainers.Enabled = false;
-            this.CHK_GymTrainers.Location = new System.Drawing.Point(9, 134);
+            this.CHK_GymTrainers.Location = new System.Drawing.Point(9, 133);
             this.CHK_GymTrainers.Name = "CHK_GymTrainers";
             this.CHK_GymTrainers.Size = new System.Drawing.Size(124, 17);
             this.CHK_GymTrainers.TabIndex = 292;
@@ -337,7 +340,7 @@
             this.CHK_StoryMEvos.AutoSize = true;
             this.CHK_StoryMEvos.Checked = true;
             this.CHK_StoryMEvos.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_StoryMEvos.Location = new System.Drawing.Point(9, 63);
+            this.CHK_StoryMEvos.Location = new System.Drawing.Point(9, 64);
             this.CHK_StoryMEvos.Name = "CHK_StoryMEvos";
             this.CHK_StoryMEvos.Size = new System.Drawing.Size(168, 17);
             this.CHK_StoryMEvos.TabIndex = 291;
@@ -348,7 +351,7 @@
             // 
             this.CHK_RandomMegaForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_RandomMegaForm.AutoSize = true;
-            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(9, 81);
+            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(9, 82);
             this.CHK_RandomMegaForm.Name = "CHK_RandomMegaForm";
             this.CHK_RandomMegaForm.Size = new System.Drawing.Size(127, 17);
             this.CHK_RandomMegaForm.TabIndex = 294;
@@ -359,7 +362,7 @@
             // 
             this.CHK_TypeTheme.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_TypeTheme.AutoSize = true;
-            this.CHK_TypeTheme.Location = new System.Drawing.Point(9, 118);
+            this.CHK_TypeTheme.Location = new System.Drawing.Point(9, 117);
             this.CHK_TypeTheme.Name = "CHK_TypeTheme";
             this.CHK_TypeTheme.Size = new System.Drawing.Size(127, 17);
             this.CHK_TypeTheme.TabIndex = 289;
@@ -477,7 +480,7 @@
             // 
             this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_6PKM.AutoSize = true;
-            this.CHK_6PKM.Location = new System.Drawing.Point(21, 215);
+            this.CHK_6PKM.Location = new System.Drawing.Point(21, 205);
             this.CHK_6PKM.Name = "CHK_6PKM";
             this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
             this.CHK_6PKM.TabIndex = 293;
@@ -491,7 +494,7 @@
             this.CHK_IgnoreSpecialClass.AutoSize = true;
             this.CHK_IgnoreSpecialClass.Checked = true;
             this.CHK_IgnoreSpecialClass.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_IgnoreSpecialClass.Location = new System.Drawing.Point(40, 377);
+            this.CHK_IgnoreSpecialClass.Location = new System.Drawing.Point(40, 387);
             this.CHK_IgnoreSpecialClass.Name = "CHK_IgnoreSpecialClass";
             this.CHK_IgnoreSpecialClass.Size = new System.Drawing.Size(133, 17);
             this.CHK_IgnoreSpecialClass.TabIndex = 324;
@@ -504,7 +507,7 @@
             this.CHK_OnlySingles.AutoSize = true;
             this.CHK_OnlySingles.Checked = true;
             this.CHK_OnlySingles.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_OnlySingles.Location = new System.Drawing.Point(40, 391);
+            this.CHK_OnlySingles.Location = new System.Drawing.Point(40, 401);
             this.CHK_OnlySingles.Name = "CHK_OnlySingles";
             this.CHK_OnlySingles.Size = new System.Drawing.Size(114, 17);
             this.CHK_OnlySingles.TabIndex = 325;
@@ -514,7 +517,7 @@
             // NUD_Damage
             // 
             this.NUD_Damage.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_Damage.Location = new System.Drawing.Point(213, 275);
+            this.NUD_Damage.Location = new System.Drawing.Point(226, 264);
             this.NUD_Damage.Maximum = new decimal(new int[] {
             4,
             0,
@@ -535,7 +538,7 @@
             this.CHK_Damage.AutoSize = true;
             this.CHK_Damage.Checked = true;
             this.CHK_Damage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Damage.Location = new System.Drawing.Point(21, 276);
+            this.CHK_Damage.Location = new System.Drawing.Point(21, 265);
             this.CHK_Damage.Name = "CHK_Damage";
             this.CHK_Damage.Size = new System.Drawing.Size(192, 17);
             this.CHK_Damage.TabIndex = 327;
@@ -548,7 +551,7 @@
             this.CHK_STAB.AutoSize = true;
             this.CHK_STAB.Checked = true;
             this.CHK_STAB.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_STAB.Location = new System.Drawing.Point(21, 295);
+            this.CHK_STAB.Location = new System.Drawing.Point(21, 286);
             this.CHK_STAB.Name = "CHK_STAB";
             this.CHK_STAB.Size = new System.Drawing.Size(172, 17);
             this.CHK_STAB.TabIndex = 328;
@@ -558,7 +561,7 @@
             // NUD_STAB
             // 
             this.NUD_STAB.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_STAB.Location = new System.Drawing.Point(213, 296);
+            this.NUD_STAB.Location = new System.Drawing.Point(226, 285);
             this.NUD_STAB.Maximum = new decimal(new int[] {
             4,
             0,
@@ -581,9 +584,8 @@
             this.CB_Moves.Items.AddRange(new object[] {
             "Don\'t Modify",
             "Randomize All",
-            "Use Levelup Only",
-            "High Powered Attacks"});
-            this.CB_Moves.Location = new System.Drawing.Point(67, 251);
+            "Use Levelup Only"});
+            this.CB_Moves.Location = new System.Drawing.Point(67, 223);
             this.CB_Moves.Name = "CB_Moves";
             this.CB_Moves.Size = new System.Drawing.Size(135, 21);
             this.CB_Moves.TabIndex = 330;
@@ -593,7 +595,7 @@
             // 
             this.L_Moves.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.L_Moves.AutoSize = true;
-            this.L_Moves.Location = new System.Drawing.Point(19, 254);
+            this.L_Moves.Location = new System.Drawing.Point(19, 226);
             this.L_Moves.Name = "L_Moves";
             this.L_Moves.Size = new System.Drawing.Size(42, 13);
             this.L_Moves.TabIndex = 331;
@@ -604,18 +606,49 @@
             this.CHK_NoFixedDamage.AutoSize = true;
             this.CHK_NoFixedDamage.Checked = true;
             this.CHK_NoFixedDamage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_NoFixedDamage.Location = new System.Drawing.Point(21, 231);
+            this.CHK_NoFixedDamage.Location = new System.Drawing.Point(21, 305);
             this.CHK_NoFixedDamage.Name = "CHK_NoFixedDamage";
             this.CHK_NoFixedDamage.Size = new System.Drawing.Size(281, 17);
             this.CHK_NoFixedDamage.TabIndex = 332;
             this.CHK_NoFixedDamage.Text = "No Fixed Damage Moves (Dragon Rage/Sonic Boom)";
             this.CHK_NoFixedDamage.UseVisualStyleBackColor = true;
             // 
+            // CHK_ForceHighPower
+            // 
+            this.CHK_ForceHighPower.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.CHK_ForceHighPower.AutoSize = true;
+            this.CHK_ForceHighPower.Location = new System.Drawing.Point(21, 245);
+            this.CHK_ForceHighPower.Name = "CHK_ForceHighPower";
+            this.CHK_ForceHighPower.Size = new System.Drawing.Size(203, 17);
+            this.CHK_ForceHighPower.TabIndex = 344;
+            this.CHK_ForceHighPower.Text = "Force High-Powered Attacks at Level";
+            this.CHK_ForceHighPower.UseVisualStyleBackColor = true;
+            // 
+            // NUD_ForceHighPower
+            // 
+            this.NUD_ForceHighPower.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.NUD_ForceHighPower.Location = new System.Drawing.Point(226, 243);
+            this.NUD_ForceHighPower.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.NUD_ForceHighPower.Name = "NUD_ForceHighPower";
+            this.NUD_ForceHighPower.Size = new System.Drawing.Size(35, 20);
+            this.NUD_ForceHighPower.TabIndex = 343;
+            this.NUD_ForceHighPower.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            // 
             // TrainerRand
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(304, 447);
+            this.ClientSize = new System.Drawing.Size(304, 465);
+            this.Controls.Add(this.CHK_ForceHighPower);
+            this.Controls.Add(this.NUD_ForceHighPower);
             this.Controls.Add(this.CHK_NoFixedDamage);
             this.Controls.Add(this.L_Moves);
             this.Controls.Add(this.CHK_6PKM);
@@ -654,6 +687,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Damage)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_STAB)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceHighPower)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -701,5 +735,7 @@
         private System.Windows.Forms.CheckBox CHK_NoFixedDamage;
         private System.Windows.Forms.NumericUpDown NUD_ForceFullyEvolved;
         private System.Windows.Forms.CheckBox CHK_ForceFullyEvolved;
+        private System.Windows.Forms.CheckBox CHK_ForceHighPower;
+        private System.Windows.Forms.NumericUpDown NUD_ForceHighPower;
     }
 }

--- a/pk3DS/Subforms/Gen6/TrainerRand.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.cs
@@ -41,7 +41,6 @@ namespace pk3DS
 
             RSTE.rMove = CB_Moves.SelectedIndex == 1;
             RSTE.rNoMove = CB_Moves.SelectedIndex == 2;
-            RSTE.rHighPower = CB_Moves.SelectedIndex == 3;
             if (RSTE.rMove)
             {
                 RSTE.rDMG = CHK_Damage.Checked;
@@ -75,6 +74,8 @@ namespace pk3DS
             RSTE.rRandomMegas = CHK_RandomMegaForm.Checked;
             RSTE.rForceFullyEvolved = CHK_ForceFullyEvolved.Checked;
             RSTE.rForceFullyEvolvedLevel = NUD_ForceFullyEvolved.Value;
+            RSTE.rForceHighPower = CHK_ForceHighPower.Checked;
+            RSTE.rForceHighPowerLevel = NUD_ForceHighPower.Value;
 
             if (CHK_StoryMEvos.Checked)
             {

--- a/pk3DS/Subforms/Gen7/SMTE.Designer.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.Designer.cs
@@ -191,6 +191,8 @@
             this.CHK_TypeTheme = new System.Windows.Forms.CheckBox();
             this.CHK_IgnoreSpecialClass = new System.Windows.Forms.CheckBox();
             this.CHK_RandomClass = new System.Windows.Forms.CheckBox();
+            this.NUD_ForceHighPower = new System.Windows.Forms.NumericUpDown();
+            this.CHK_ForceHighPower = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Team1)).BeginInit();
             this.mnuVSD.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PB_Team2)).BeginInit();
@@ -241,6 +243,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_RMin)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_RMax)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceHighPower)).BeginInit();
             this.SuspendLayout();
             // 
             // CB_TrainerID
@@ -1808,6 +1811,8 @@
             // 
             // Tab_PKM2
             // 
+            this.Tab_PKM2.Controls.Add(this.CHK_ForceHighPower);
+            this.Tab_PKM2.Controls.Add(this.NUD_ForceHighPower);
             this.Tab_PKM2.Controls.Add(this.CHK_NoFixedDamage);
             this.Tab_PKM2.Controls.Add(this.CHK_BeneficialEVs);
             this.Tab_PKM2.Controls.Add(this.L_Moves);
@@ -1832,7 +1837,7 @@
             this.CHK_NoFixedDamage.AutoSize = true;
             this.CHK_NoFixedDamage.Checked = true;
             this.CHK_NoFixedDamage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_NoFixedDamage.Location = new System.Drawing.Point(6, 31);
+            this.CHK_NoFixedDamage.Location = new System.Drawing.Point(6, 86);
             this.CHK_NoFixedDamage.Name = "CHK_NoFixedDamage";
             this.CHK_NoFixedDamage.Size = new System.Drawing.Size(281, 17);
             this.CHK_NoFixedDamage.TabIndex = 340;
@@ -1845,7 +1850,7 @@
             this.CHK_BeneficialEVs.AutoSize = true;
             this.CHK_BeneficialEVs.Checked = true;
             this.CHK_BeneficialEVs.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_BeneficialEVs.Location = new System.Drawing.Point(201, 115);
+            this.CHK_BeneficialEVs.Location = new System.Drawing.Point(201, 118);
             this.CHK_BeneficialEVs.Name = "CHK_BeneficialEVs";
             this.CHK_BeneficialEVs.Size = new System.Drawing.Size(75, 17);
             this.CHK_BeneficialEVs.TabIndex = 339;
@@ -1856,7 +1861,7 @@
             // 
             this.L_Moves.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.L_Moves.AutoSize = true;
-            this.L_Moves.Location = new System.Drawing.Point(6, 11);
+            this.L_Moves.Location = new System.Drawing.Point(6, 7);
             this.L_Moves.Name = "L_Moves";
             this.L_Moves.Size = new System.Drawing.Size(42, 13);
             this.L_Moves.TabIndex = 338;
@@ -1870,9 +1875,8 @@
             this.CB_Moves.Items.AddRange(new object[] {
             "Don\'t Modify",
             "Randomize All",
-            "Use Levelup Only",
-            "High Powered Attacks"});
-            this.CB_Moves.Location = new System.Drawing.Point(52, 8);
+            "Use Levelup Only"});
+            this.CB_Moves.Location = new System.Drawing.Point(52, 4);
             this.CB_Moves.Name = "CB_Moves";
             this.CB_Moves.Size = new System.Drawing.Size(135, 21);
             this.CB_Moves.TabIndex = 337;
@@ -1884,7 +1888,7 @@
             this.CHK_MaxDiffPKM.AutoSize = true;
             this.CHK_MaxDiffPKM.Checked = true;
             this.CHK_MaxDiffPKM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_MaxDiffPKM.Location = new System.Drawing.Point(201, 99);
+            this.CHK_MaxDiffPKM.Location = new System.Drawing.Point(201, 102);
             this.CHK_MaxDiffPKM.Name = "CHK_MaxDiffPKM";
             this.CHK_MaxDiffPKM.Size = new System.Drawing.Size(64, 17);
             this.CHK_MaxDiffPKM.TabIndex = 332;
@@ -1894,7 +1898,7 @@
             // NUD_Damage
             // 
             this.NUD_Damage.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_Damage.Location = new System.Drawing.Point(201, 49);
+            this.NUD_Damage.Location = new System.Drawing.Point(211, 45);
             this.NUD_Damage.Maximum = new decimal(new int[] {
             4,
             0,
@@ -1915,7 +1919,7 @@
             this.CHK_RandomAbilities.AutoSize = true;
             this.CHK_RandomAbilities.Checked = true;
             this.CHK_RandomAbilities.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomAbilities.Location = new System.Drawing.Point(6, 115);
+            this.CHK_RandomAbilities.Location = new System.Drawing.Point(6, 118);
             this.CHK_RandomAbilities.Name = "CHK_RandomAbilities";
             this.CHK_RandomAbilities.Size = new System.Drawing.Size(193, 17);
             this.CHK_RandomAbilities.TabIndex = 331;
@@ -1925,7 +1929,7 @@
             // NUD_STAB
             // 
             this.NUD_STAB.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.NUD_STAB.Location = new System.Drawing.Point(201, 70);
+            this.NUD_STAB.Location = new System.Drawing.Point(211, 66);
             this.NUD_STAB.Maximum = new decimal(new int[] {
             4,
             0,
@@ -1946,7 +1950,7 @@
             this.CHK_Damage.AutoSize = true;
             this.CHK_Damage.Checked = true;
             this.CHK_Damage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Damage.Location = new System.Drawing.Point(6, 51);
+            this.CHK_Damage.Location = new System.Drawing.Point(6, 46);
             this.CHK_Damage.Name = "CHK_Damage";
             this.CHK_Damage.Size = new System.Drawing.Size(192, 17);
             this.CHK_Damage.TabIndex = 334;
@@ -1960,7 +1964,7 @@
             this.CHK_RandomItems.AutoSize = true;
             this.CHK_RandomItems.Checked = true;
             this.CHK_RandomItems.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomItems.Location = new System.Drawing.Point(6, 99);
+            this.CHK_RandomItems.Location = new System.Drawing.Point(6, 102);
             this.CHK_RandomItems.Name = "CHK_RandomItems";
             this.CHK_RandomItems.Size = new System.Drawing.Size(119, 17);
             this.CHK_RandomItems.TabIndex = 330;
@@ -1973,7 +1977,7 @@
             this.CHK_STAB.AutoSize = true;
             this.CHK_STAB.Checked = true;
             this.CHK_STAB.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_STAB.Location = new System.Drawing.Point(6, 70);
+            this.CHK_STAB.Location = new System.Drawing.Point(6, 66);
             this.CHK_STAB.Name = "CHK_STAB";
             this.CHK_STAB.Size = new System.Drawing.Size(172, 17);
             this.CHK_STAB.TabIndex = 335;
@@ -2153,6 +2157,35 @@
             this.CHK_RandomClass.UseVisualStyleBackColor = true;
             this.CHK_RandomClass.CheckedChanged += new System.EventHandler(this.CHK_RandomClass_CheckedChanged);
             // 
+            // NUD_ForceHighPower
+            // 
+            this.NUD_ForceHighPower.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.NUD_ForceHighPower.Location = new System.Drawing.Point(211, 24);
+            this.NUD_ForceHighPower.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.NUD_ForceHighPower.Name = "NUD_ForceHighPower";
+            this.NUD_ForceHighPower.Size = new System.Drawing.Size(35, 20);
+            this.NUD_ForceHighPower.TabIndex = 341;
+            this.NUD_ForceHighPower.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            // 
+            // CHK_ForceHighPower
+            // 
+            this.CHK_ForceHighPower.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.CHK_ForceHighPower.AutoSize = true;
+            this.CHK_ForceHighPower.Location = new System.Drawing.Point(6, 26);
+            this.CHK_ForceHighPower.Name = "CHK_ForceHighPower";
+            this.CHK_ForceHighPower.Size = new System.Drawing.Size(203, 17);
+            this.CHK_ForceHighPower.TabIndex = 342;
+            this.CHK_ForceHighPower.Text = "Force High-Powered Attacks at Level";
+            this.CHK_ForceHighPower.UseVisualStyleBackColor = true;
+            // 
             // SMTE
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2233,6 +2266,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_RMin)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_RMax)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceHighPower)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -2400,6 +2434,8 @@
         private System.Windows.Forms.NumericUpDown NUD_ForceFullyEvolved;
         private System.Windows.Forms.CheckBox CHK_ForceFullyEvolved;
         private System.Windows.Forms.CheckBox CHK_6PKM;
+        private System.Windows.Forms.CheckBox CHK_ForceHighPower;
+        private System.Windows.Forms.NumericUpDown NUD_ForceHighPower;
     }
 }
 

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -702,10 +702,12 @@ namespace pk3DS
                         case 2: // Current LevelUp
                             pk.Moves = learn.GetCurrentMoves(pk.Species, pk.Form, pk.Level, 4);
                             break;
-                        case 3: // High Attacks
-                            pk.Moves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
-                            break;
                     }
+
+                    // high-power attacks
+                    if (CHK_ForceHighPower.Checked && pk.Level >= NUD_ForceHighPower.Value)
+                        pk.Moves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
+
                     // sanitize moves
                     if (CB_Moves.SelectedIndex > 1) // learn source
                     {


### PR DESCRIPTION
Makes it similar to force final evolution - the user can specify a Level for which all Pokemon will have high-powered attacks. To have the same effect as initial implementation, set `NUD_ForceHighPower` to 1.

Decided to add this because some Pokemon with their current levelup moves are just bad. Example is a Lv. 58 Mawile only having Sucker Punch as its main attacking move, rather than stuff like Iron Head and Play Rough.

![screenshot_1](https://user-images.githubusercontent.com/17801814/34592548-e653641c-f192-11e7-80ea-a09e79005eb2.png)
![screenshot_2](https://user-images.githubusercontent.com/17801814/34592550-e838ba8e-f192-11e7-8aba-1e69d761c84a.png)
  