### PR TITLE
Add remove trade evo option

### DIFF
--- a/pk3DS.Core/Randomizers/EvolutionRandomizer.cs
+++ b/pk3DS.Core/Randomizers/EvolutionRandomizer.cs
@@ -26,6 +26,15 @@ namespace pk3DS.Core.Randomizers
             }
         }
 
+        public void ExecuteTrade()
+        {
+            for (var i = 0; i < Evolutions.Length; i++)
+            {
+                var evo = Evolutions[i];
+                Trade(evo, i);
+            }
+        }
+
         private void Randomize(EvolutionSet evo, int i)
         {
             var evos = evo.PossibleEvolutions;
@@ -33,6 +42,43 @@ namespace pk3DS.Core.Randomizers
             {
                 if (v.Method > 0)
                     v.Species = Randomizer.GetRandomSpecies(v.Species, i);
+            }
+        }
+
+        private void Trade(EvolutionSet evo, int i)
+        {
+            var evos = evo.PossibleEvolutions;
+            foreach (EvolutionMethod v in evos)
+            {
+                if ((Config.XY || Config.ORAS) && v.Method == 5) // Gen 6 uses Argument rather than Level
+                {
+                    if (i == 708 || i == 710) // Phantump/Pumpkaboo
+                        v.Argument = 20;
+                    else
+                        v.Argument = 30;
+                    v.Method = 4; // trade -> level up
+                }
+
+                if ((Config.SM || Config.USUM) && v.Method == 5)
+                {
+                    if (i == 708 || i == 710 || i == 876 || i == 877 | i == 878) // Phantump/Pumpkaboo forms
+                        v.Level = 20;
+                    else
+                        v.Level = 30;
+                    v.Method = 4; // trade -> level up
+                }
+                
+                if (v.Method == 6) // trade with held item -> level up with held item
+                    v.Method = 19;
+
+                if (v.Method == 7) // trade for opposite -> level up with party
+                {
+                    if (i == 588)
+                        v.Argument = 616; // Karrablast with Shelmet
+                    if (i == 616)
+                        v.Argument = 588; // Shelmet with Karrablast
+                    v.Method = 22;
+                }
             }
         }
     }

--- a/pk3DS/Subforms/Gen6/EvolutionEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/EvolutionEditor6.Designer.cs
@@ -34,32 +34,24 @@
             this.CB_M1 = new System.Windows.Forms.ComboBox();
             this.L_M1 = new System.Windows.Forms.Label();
             this.CB_I1 = new System.Windows.Forms.ComboBox();
-            this.CB_P1 = new System.Windows.Forms.ComboBox();
-            this.CB_P2 = new System.Windows.Forms.ComboBox();
             this.CB_I2 = new System.Windows.Forms.ComboBox();
             this.L_M2 = new System.Windows.Forms.Label();
             this.CB_M2 = new System.Windows.Forms.ComboBox();
-            this.CB_P3 = new System.Windows.Forms.ComboBox();
             this.CB_I3 = new System.Windows.Forms.ComboBox();
             this.L_M3 = new System.Windows.Forms.Label();
             this.CB_M3 = new System.Windows.Forms.ComboBox();
-            this.CB_P4 = new System.Windows.Forms.ComboBox();
             this.CB_I4 = new System.Windows.Forms.ComboBox();
             this.L_M4 = new System.Windows.Forms.Label();
             this.CB_M4 = new System.Windows.Forms.ComboBox();
-            this.CB_P5 = new System.Windows.Forms.ComboBox();
             this.CB_I5 = new System.Windows.Forms.ComboBox();
             this.L_M5 = new System.Windows.Forms.Label();
             this.CB_M5 = new System.Windows.Forms.ComboBox();
-            this.CB_P8 = new System.Windows.Forms.ComboBox();
             this.CB_I8 = new System.Windows.Forms.ComboBox();
             this.L_M8 = new System.Windows.Forms.Label();
             this.CB_M8 = new System.Windows.Forms.ComboBox();
-            this.CB_P7 = new System.Windows.Forms.ComboBox();
             this.CB_I7 = new System.Windows.Forms.ComboBox();
             this.L_M7 = new System.Windows.Forms.Label();
             this.CB_M7 = new System.Windows.Forms.ComboBox();
-            this.CB_P6 = new System.Windows.Forms.ComboBox();
             this.CB_I6 = new System.Windows.Forms.ComboBox();
             this.L_M6 = new System.Windows.Forms.Label();
             this.CB_M6 = new System.Windows.Forms.ComboBox();
@@ -77,6 +69,15 @@
             this.CHK_BST = new System.Windows.Forms.CheckBox();
             this.CHK_Type = new System.Windows.Forms.CheckBox();
             this.CHK_Exp = new System.Windows.Forms.CheckBox();
+            this.B_Trade = new System.Windows.Forms.Button();
+            this.CB_P8 = new System.Windows.Forms.ComboBox();
+            this.CB_P7 = new System.Windows.Forms.ComboBox();
+            this.CB_P6 = new System.Windows.Forms.ComboBox();
+            this.CB_P5 = new System.Windows.Forms.ComboBox();
+            this.CB_P4 = new System.Windows.Forms.ComboBox();
+            this.CB_P3 = new System.Windows.Forms.ComboBox();
+            this.CB_P2 = new System.Windows.Forms.ComboBox();
+            this.CB_P1 = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.PB_1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PB_4)).BeginInit();
@@ -93,7 +94,7 @@
             this.CB_Species.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Species.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Species.FormattingEnabled = true;
-            this.CB_Species.Location = new System.Drawing.Point(66, 12);
+            this.CB_Species.Location = new System.Drawing.Point(58, 12);
             this.CB_Species.Name = "CB_Species";
             this.CB_Species.Size = new System.Drawing.Size(121, 21);
             this.CB_Species.TabIndex = 1;
@@ -102,7 +103,7 @@
             // L_Species
             // 
             this.L_Species.AutoSize = true;
-            this.L_Species.Location = new System.Drawing.Point(12, 15);
+            this.L_Species.Location = new System.Drawing.Point(8, 15);
             this.L_Species.Name = "L_Species";
             this.L_Species.Size = new System.Drawing.Size(48, 13);
             this.L_Species.TabIndex = 2;
@@ -110,7 +111,7 @@
             // 
             // B_Dump
             // 
-            this.B_Dump.Location = new System.Drawing.Point(193, 11);
+            this.B_Dump.Location = new System.Drawing.Point(183, 11);
             this.B_Dump.Name = "B_Dump";
             this.B_Dump.Size = new System.Drawing.Size(59, 23);
             this.B_Dump.TabIndex = 5;
@@ -150,26 +151,6 @@
             this.CB_I1.TabIndex = 9;
             this.CB_I1.SelectedIndexChanged += new System.EventHandler(this.changeInto);
             // 
-            // CB_P1
-            // 
-            this.CB_P1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P1.FormattingEnabled = true;
-            this.CB_P1.Location = new System.Drawing.Point(79, 69);
-            this.CB_P1.Name = "CB_P1";
-            this.CB_P1.Size = new System.Drawing.Size(121, 21);
-            this.CB_P1.TabIndex = 10;
-            // 
-            // CB_P2
-            // 
-            this.CB_P2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P2.FormattingEnabled = true;
-            this.CB_P2.Location = new System.Drawing.Point(79, 123);
-            this.CB_P2.Name = "CB_P2";
-            this.CB_P2.Size = new System.Drawing.Size(121, 21);
-            this.CB_P2.TabIndex = 16;
-            // 
             // CB_I2
             // 
             this.CB_I2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
@@ -201,16 +182,6 @@
             this.CB_M2.Size = new System.Drawing.Size(150, 21);
             this.CB_M2.TabIndex = 12;
             this.CB_M2.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
-            // 
-            // CB_P3
-            // 
-            this.CB_P3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P3.FormattingEnabled = true;
-            this.CB_P3.Location = new System.Drawing.Point(79, 177);
-            this.CB_P3.Name = "CB_P3";
-            this.CB_P3.Size = new System.Drawing.Size(121, 21);
-            this.CB_P3.TabIndex = 22;
             // 
             // CB_I3
             // 
@@ -244,16 +215,6 @@
             this.CB_M3.TabIndex = 18;
             this.CB_M3.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
             // 
-            // CB_P4
-            // 
-            this.CB_P4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P4.FormattingEnabled = true;
-            this.CB_P4.Location = new System.Drawing.Point(79, 231);
-            this.CB_P4.Name = "CB_P4";
-            this.CB_P4.Size = new System.Drawing.Size(121, 21);
-            this.CB_P4.TabIndex = 28;
-            // 
             // CB_I4
             // 
             this.CB_I4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
@@ -285,16 +246,6 @@
             this.CB_M4.Size = new System.Drawing.Size(150, 21);
             this.CB_M4.TabIndex = 24;
             this.CB_M4.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
-            // 
-            // CB_P5
-            // 
-            this.CB_P5.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P5.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P5.FormattingEnabled = true;
-            this.CB_P5.Location = new System.Drawing.Point(79, 285);
-            this.CB_P5.Name = "CB_P5";
-            this.CB_P5.Size = new System.Drawing.Size(121, 21);
-            this.CB_P5.TabIndex = 34;
             // 
             // CB_I5
             // 
@@ -328,16 +279,6 @@
             this.CB_M5.TabIndex = 30;
             this.CB_M5.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
             // 
-            // CB_P8
-            // 
-            this.CB_P8.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P8.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P8.FormattingEnabled = true;
-            this.CB_P8.Location = new System.Drawing.Point(79, 447);
-            this.CB_P8.Name = "CB_P8";
-            this.CB_P8.Size = new System.Drawing.Size(121, 21);
-            this.CB_P8.TabIndex = 52;
-            // 
             // CB_I8
             // 
             this.CB_I8.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
@@ -370,16 +311,6 @@
             this.CB_M8.TabIndex = 48;
             this.CB_M8.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
             // 
-            // CB_P7
-            // 
-            this.CB_P7.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P7.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P7.FormattingEnabled = true;
-            this.CB_P7.Location = new System.Drawing.Point(79, 393);
-            this.CB_P7.Name = "CB_P7";
-            this.CB_P7.Size = new System.Drawing.Size(121, 21);
-            this.CB_P7.TabIndex = 46;
-            // 
             // CB_I7
             // 
             this.CB_I7.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
@@ -411,16 +342,6 @@
             this.CB_M7.Size = new System.Drawing.Size(150, 21);
             this.CB_M7.TabIndex = 42;
             this.CB_M7.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
-            // 
-            // CB_P6
-            // 
-            this.CB_P6.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.CB_P6.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_P6.FormattingEnabled = true;
-            this.CB_P6.Location = new System.Drawing.Point(79, 339);
-            this.CB_P6.Name = "CB_P6";
-            this.CB_P6.Size = new System.Drawing.Size(121, 21);
-            this.CB_P6.TabIndex = 40;
             // 
             // CB_I6
             // 
@@ -546,7 +467,7 @@
             // 
             this.L_Protip.AutoSize = true;
             this.L_Protip.ForeColor = System.Drawing.Color.Red;
-            this.L_Protip.Location = new System.Drawing.Point(198, 11);
+            this.L_Protip.Location = new System.Drawing.Point(198, 9);
             this.L_Protip.Name = "L_Protip";
             this.L_Protip.Size = new System.Drawing.Size(153, 13);
             this.L_Protip.TabIndex = 66;
@@ -583,16 +504,107 @@
             this.CHK_Exp.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CHK_Exp.Location = new System.Drawing.Point(6, 23);
             this.CHK_Exp.Name = "CHK_Exp";
-            this.CHK_Exp.Size = new System.Drawing.Size(219, 17);
+            this.CHK_Exp.Size = new System.Drawing.Size(222, 17);
             this.CHK_Exp.TabIndex = 63;
-            this.CHK_Exp.Text = "Share the same Exp Growth as Evolution";
+            this.CHK_Exp.Text = "Share the same EXP Growth as Evolution";
             this.CHK_Exp.UseVisualStyleBackColor = true;
             // 
-            // Evolution
+            // B_Trade
+            // 
+            this.B_Trade.Location = new System.Drawing.Point(244, 11);
+            this.B_Trade.Name = "B_Trade";
+            this.B_Trade.Size = new System.Drawing.Size(143, 23);
+            this.B_Trade.TabIndex = 116;
+            this.B_Trade.Text = "Remove Trade Evolutions";
+            this.B_Trade.UseVisualStyleBackColor = true;
+            this.B_Trade.Click += new System.EventHandler(this.B_Trade_Click);
+            // 
+            // CB_P8
+            // 
+            this.CB_P8.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P8.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P8.FormattingEnabled = true;
+            this.CB_P8.Location = new System.Drawing.Point(79, 447);
+            this.CB_P8.Name = "CB_P8";
+            this.CB_P8.Size = new System.Drawing.Size(121, 21);
+            this.CB_P8.TabIndex = 52;
+            // 
+            // CB_P7
+            // 
+            this.CB_P7.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P7.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P7.FormattingEnabled = true;
+            this.CB_P7.Location = new System.Drawing.Point(79, 393);
+            this.CB_P7.Name = "CB_P7";
+            this.CB_P7.Size = new System.Drawing.Size(121, 21);
+            this.CB_P7.TabIndex = 46;
+            // 
+            // CB_P6
+            // 
+            this.CB_P6.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P6.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P6.FormattingEnabled = true;
+            this.CB_P6.Location = new System.Drawing.Point(79, 339);
+            this.CB_P6.Name = "CB_P6";
+            this.CB_P6.Size = new System.Drawing.Size(121, 21);
+            this.CB_P6.TabIndex = 40;
+            // 
+            // CB_P5
+            // 
+            this.CB_P5.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P5.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P5.FormattingEnabled = true;
+            this.CB_P5.Location = new System.Drawing.Point(79, 285);
+            this.CB_P5.Name = "CB_P5";
+            this.CB_P5.Size = new System.Drawing.Size(121, 21);
+            this.CB_P5.TabIndex = 34;
+            // 
+            // CB_P4
+            // 
+            this.CB_P4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P4.FormattingEnabled = true;
+            this.CB_P4.Location = new System.Drawing.Point(79, 231);
+            this.CB_P4.Name = "CB_P4";
+            this.CB_P4.Size = new System.Drawing.Size(121, 21);
+            this.CB_P4.TabIndex = 28;
+            // 
+            // CB_P3
+            // 
+            this.CB_P3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P3.FormattingEnabled = true;
+            this.CB_P3.Location = new System.Drawing.Point(79, 177);
+            this.CB_P3.Name = "CB_P3";
+            this.CB_P3.Size = new System.Drawing.Size(121, 21);
+            this.CB_P3.TabIndex = 22;
+            // 
+            // CB_P2
+            // 
+            this.CB_P2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P2.FormattingEnabled = true;
+            this.CB_P2.Location = new System.Drawing.Point(79, 123);
+            this.CB_P2.Name = "CB_P2";
+            this.CB_P2.Size = new System.Drawing.Size(121, 21);
+            this.CB_P2.TabIndex = 16;
+            // 
+            // CB_P1
+            // 
+            this.CB_P1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
+            this.CB_P1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_P1.FormattingEnabled = true;
+            this.CB_P1.Location = new System.Drawing.Point(79, 69);
+            this.CB_P1.Name = "CB_P1";
+            this.CB_P1.Size = new System.Drawing.Size(121, 21);
+            this.CB_P1.TabIndex = 10;
+            // 
+            // EvolutionEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 562);
+            this.ClientSize = new System.Drawing.Size(394, 561);
+            this.Controls.Add(this.B_Trade);
             this.Controls.Add(this.GB_Randomizer);
             this.Controls.Add(this.PB_8);
             this.Controls.Add(this.PB_7);
@@ -667,32 +679,24 @@
         private System.Windows.Forms.ComboBox CB_M1;
         private System.Windows.Forms.Label L_M1;
         private System.Windows.Forms.ComboBox CB_I1;
-        private System.Windows.Forms.ComboBox CB_P1;
-        private System.Windows.Forms.ComboBox CB_P2;
         private System.Windows.Forms.ComboBox CB_I2;
         private System.Windows.Forms.Label L_M2;
         private System.Windows.Forms.ComboBox CB_M2;
-        private System.Windows.Forms.ComboBox CB_P3;
         private System.Windows.Forms.ComboBox CB_I3;
         private System.Windows.Forms.Label L_M3;
         private System.Windows.Forms.ComboBox CB_M3;
-        private System.Windows.Forms.ComboBox CB_P4;
         private System.Windows.Forms.ComboBox CB_I4;
         private System.Windows.Forms.Label L_M4;
         private System.Windows.Forms.ComboBox CB_M4;
-        private System.Windows.Forms.ComboBox CB_P5;
         private System.Windows.Forms.ComboBox CB_I5;
         private System.Windows.Forms.Label L_M5;
         private System.Windows.Forms.ComboBox CB_M5;
-        private System.Windows.Forms.ComboBox CB_P8;
         private System.Windows.Forms.ComboBox CB_I8;
         private System.Windows.Forms.Label L_M8;
         private System.Windows.Forms.ComboBox CB_M8;
-        private System.Windows.Forms.ComboBox CB_P7;
         private System.Windows.Forms.ComboBox CB_I7;
         private System.Windows.Forms.Label L_M7;
         private System.Windows.Forms.ComboBox CB_M7;
-        private System.Windows.Forms.ComboBox CB_P6;
         private System.Windows.Forms.ComboBox CB_I6;
         private System.Windows.Forms.Label L_M6;
         private System.Windows.Forms.ComboBox CB_M6;
@@ -710,5 +714,14 @@
         private System.Windows.Forms.CheckBox CHK_Type;
         private System.Windows.Forms.CheckBox CHK_BST;
         private System.Windows.Forms.Label L_Protip;
+        private System.Windows.Forms.Button B_Trade;
+        private System.Windows.Forms.ComboBox CB_P8;
+        private System.Windows.Forms.ComboBox CB_P7;
+        private System.Windows.Forms.ComboBox CB_P6;
+        private System.Windows.Forms.ComboBox CB_P5;
+        private System.Windows.Forms.ComboBox CB_P4;
+        private System.Windows.Forms.ComboBox CB_P3;
+        private System.Windows.Forms.ComboBox CB_P2;
+        private System.Windows.Forms.ComboBox CB_P1;
     }
 }

--- a/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
+++ b/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
@@ -69,14 +69,10 @@ namespace pk3DS
             foreach (ComboBox cb in mb) { foreach (string s in evolutionMethods) cb.Items.Add(s); }
             foreach (ComboBox cb in rb) { foreach (string s in specieslist) cb.Items.Add(s); }
 
-            sortedspecies = (string[])specieslist.Clone();
-            Array.Sort(sortedspecies);
-
             CB_Species.Items.Clear();
-            foreach (string s in sortedspecies) CB_Species.Items.Add(s);
-            CB_Species.Items.RemoveAt(0);
+            foreach (string s in specieslist) CB_Species.Items.Add(s);
 
-            CB_Species.SelectedIndex = 0;
+            CB_Species.SelectedIndex = 1;
             RandSettings.GetFormSettings(this, GB_Randomizer.Controls);
         }
         private readonly byte[][] files;
@@ -85,7 +81,6 @@ namespace pk3DS
         private readonly ComboBox[] mb;
         private readonly PictureBox[] pic;
         private int entry = -1;
-        private readonly string[] sortedspecies;
         private readonly string[] specieslist = Main.Config.getText(TextName.SpeciesNames);
         private readonly string[] movelist = Main.Config.getText(TextName.MoveNames);
         private readonly string[] itemlist = Main.Config.getText(TextName.ItemNames);
@@ -102,7 +97,7 @@ namespace pk3DS
             for (int i = 0; i < evo.PossibleEvolutions.Length; i++)
             {
                 if (evo.PossibleEvolutions[i].Method > 34) return; // Invalid!
-
+                
                 mb[i].SelectedIndex = evo.PossibleEvolutions[i].Method; // Which will trigger the params cb to reload the valid params list
                 pb[i].SelectedIndex = evo.PossibleEvolutions[i].Argument;
                 rb[i].SelectedIndex = evo.PossibleEvolutions[i].Species;
@@ -145,6 +140,21 @@ namespace pk3DS
             getList();
 
             WinFormsUtil.Alert("All Pokémon's Evolutions have been randomized!");
+        }
+        private void B_Trade_Click(object sender, EventArgs e)
+        {
+            if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Remove all trade evolutions?", "Evolution methods will be altered so that evolutions will be possible with only one game."))
+                return;
+
+            setList();
+            var evos = files.Select(z => new EvolutionSet6(z)).ToArray();
+            var evoRand = new EvolutionRandomizer(Main.Config, evos);
+            evoRand.Randomizer.Initialize();
+            evoRand.ExecuteTrade();
+            evos.Select(z => z.Write()).ToArray().CopyTo(files, 0);
+            getList();
+
+            WinFormsUtil.Alert("All trade evolutions have been removed!", "Trade evolutions will now occur after reaching a certain Level, or after leveling up while holding its appropriate trade item.");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {
@@ -216,7 +226,7 @@ namespace pk3DS
                 case 3: // Moves
                     { foreach (string t in movelist) pb[op].Items.Add(t); break; }
                 case 4: // Species
-                    { for (int i = 0; i < sortedspecies.Length; i++) pb[op].Items.Add(specieslist[i]); break; }
+                    { for (int i = 0; i < specieslist.Length; i++) pb[op].Items.Add(specieslist[i]); break; }
                 case 5: // 0-255 (Beauty)
                     { for (int i = 0; i <= 255; i++) pb[op].Items.Add(i.ToString()); break; }
                 case 6:

--- a/pk3DS/Subforms/Gen7/EvolutionEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/EvolutionEditor7.Designer.cs
@@ -93,6 +93,7 @@
             this.CB_I8 = new System.Windows.Forms.ComboBox();
             this.label7 = new System.Windows.Forms.Label();
             this.CB_M8 = new System.Windows.Forms.ComboBox();
+            this.B_Trade = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.PB_1)).BeginInit();
             this.GB_Randomizer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_F1)).BeginInit();
@@ -202,7 +203,7 @@
             // 
             // B_RandAll
             // 
-            this.B_RandAll.Location = new System.Drawing.Point(251, 47);
+            this.B_RandAll.Location = new System.Drawing.Point(511, 322);
             this.B_RandAll.Name = "B_RandAll";
             this.B_RandAll.Size = new System.Drawing.Size(100, 23);
             this.B_RandAll.TabIndex = 62;
@@ -216,7 +217,6 @@
             this.GB_Randomizer.Controls.Add(this.CHK_BST);
             this.GB_Randomizer.Controls.Add(this.CHK_Type);
             this.GB_Randomizer.Controls.Add(this.CHK_Exp);
-            this.GB_Randomizer.Controls.Add(this.B_RandAll);
             this.GB_Randomizer.Location = new System.Drawing.Point(16, 292);
             this.GB_Randomizer.Name = "GB_Randomizer";
             this.GB_Randomizer.Size = new System.Drawing.Size(357, 76);
@@ -228,7 +228,7 @@
             // 
             this.L_Protip.AutoSize = true;
             this.L_Protip.ForeColor = System.Drawing.Color.Red;
-            this.L_Protip.Location = new System.Drawing.Point(198, 11);
+            this.L_Protip.Location = new System.Drawing.Point(198, 9);
             this.L_Protip.Name = "L_Protip";
             this.L_Protip.Size = new System.Drawing.Size(153, 13);
             this.L_Protip.TabIndex = 66;
@@ -265,9 +265,9 @@
             this.CHK_Exp.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CHK_Exp.Location = new System.Drawing.Point(6, 23);
             this.CHK_Exp.Name = "CHK_Exp";
-            this.CHK_Exp.Size = new System.Drawing.Size(219, 17);
+            this.CHK_Exp.Size = new System.Drawing.Size(222, 17);
             this.CHK_Exp.TabIndex = 63;
-            this.CHK_Exp.Text = "Share the same Exp Growth as Evolution";
+            this.CHK_Exp.Text = "Share the same EXP Growth as Evolution";
             this.CHK_Exp.UseVisualStyleBackColor = true;
             // 
             // NUD_F1
@@ -900,15 +900,27 @@
             this.CB_M8.TabIndex = 108;
             this.CB_M8.SelectedIndexChanged += new System.EventHandler(this.changeMethod);
             // 
+            // B_Trade
+            // 
+            this.B_Trade.Location = new System.Drawing.Point(468, 345);
+            this.B_Trade.Name = "B_Trade";
+            this.B_Trade.Size = new System.Drawing.Size(143, 23);
+            this.B_Trade.TabIndex = 115;
+            this.B_Trade.Text = "Remove Trade Evolutions";
+            this.B_Trade.UseVisualStyleBackColor = true;
+            this.B_Trade.Click += new System.EventHandler(this.B_Trade_Click);
+            // 
             // EvolutionEditor7
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(624, 376);
+            this.Controls.Add(this.B_Trade);
             this.Controls.Add(this.NUD_L8);
             this.Controls.Add(this.NUD_F8);
             this.Controls.Add(this.PB_8);
             this.Controls.Add(this.CB_P8);
+            this.Controls.Add(this.B_RandAll);
             this.Controls.Add(this.CB_I8);
             this.Controls.Add(this.label7);
             this.Controls.Add(this.CB_M8);
@@ -1070,5 +1082,6 @@
         private System.Windows.Forms.ComboBox CB_I8;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.ComboBox CB_M8;
+        private System.Windows.Forms.Button B_Trade;
     }
 }

--- a/pk3DS/Subforms/Gen7/EvolutionEditor7.cs
+++ b/pk3DS/Subforms/Gen7/EvolutionEditor7.cs
@@ -89,14 +89,10 @@ namespace pk3DS
             foreach (ComboBox cb in mb) { cb.Items.AddRange(evos.ToArray()); }
             foreach (ComboBox cb in rb) { cb.Items.AddRange(specieslist.Take(Main.Config.MaxSpeciesID+1).ToArray()); }
 
-            sortedspecies = (string[])specieslist.Clone();
-            Array.Sort(sortedspecies);
-
             CB_Species.Items.Clear();
-            foreach (string s in sortedspecies) CB_Species.Items.Add(s);
-            CB_Species.Items.RemoveAt(0);
+            foreach (string s in specieslist) CB_Species.Items.Add(s);
 
-            CB_Species.SelectedIndex = 0;
+            CB_Species.SelectedIndex = 1;
             RandSettings.GetFormSettings(this, GB_Randomizer.Controls);
         }
         private readonly byte[][] files;
@@ -104,7 +100,6 @@ namespace pk3DS
         private readonly NumericUpDown[] fb, lb;
         private readonly PictureBox[] pic;
         private int entry = -1;
-        private readonly string[] sortedspecies;
         private readonly string[] specieslist = Main.Config.getText(TextName.SpeciesNames);
         private readonly string[] movelist = Main.Config.getText(TextName.MoveNames);
         private readonly string[] itemlist = Main.Config.getText(TextName.ItemNames);
@@ -174,6 +169,21 @@ namespace pk3DS
             getList();
 
             WinFormsUtil.Alert("All Pokémon's Evolutions have been randomized!");
+        }
+        private void B_Trade_Click(object sender, EventArgs e)
+        {
+            if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Remove all trade evolutions?", "Evolution methods will be altered so that evolutions will be possible with only one game."))
+                return;
+
+            setList();
+            var evos = files.Select(z => new EvolutionSet7(z)).ToArray();
+            var evoRand = new EvolutionRandomizer(Main.Config, evos);
+            evoRand.Randomizer.Initialize();
+            evoRand.ExecuteTrade();
+            evos.Select(z => z.Write()).ToArray().CopyTo(files, 0);
+            getList();
+
+            WinFormsUtil.Alert("All trade evolutions have been removed!", "Trade evolutions will now occur after reaching a certain Level, or after leveling up while holding its appropriate trade item.");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {
@@ -262,7 +272,7 @@ namespace pk3DS
                 case 3: // Moves
                     { foreach (string t in movelist) pb[op].Items.Add(t); break; }
                 case 4: // Species
-                    { for (int i = 0; i < sortedspecies.Length; i++) pb[op].Items.Add(specieslist[i]); break; }
+                    { for (int i = 0; i < specieslist.Length; i++) pb[op].Items.Add(specieslist[i]); break; }
                 case 5: // 0-255 (Beauty)
                     { for (int i = 0; i <= 255; i++) pb[op].Items.Add(i.ToString()); break; }
                 case 6:


### PR DESCRIPTION
Editor now defaults on Bulbasaur when opened, and no longer sorts alphabetically (was mainly for Shelmet/Karrablast modification).

Decided on static levels rather than user-specified or dynamic; can always edit the source code to your desired result, or just use the editor. ;)

Resolves #168.
![image](https://user-images.githubusercontent.com/17801814/35790559-f7512c0e-0a10-11e8-8ce2-1d2dce124d13.png)