### PR TITLE
Add more Metronome options

### DIFF
--- a/pk3DS/Subforms/Gen6/MoveEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/MoveEditor6.Designer.cs
@@ -90,8 +90,9 @@
             this.L_0x21 = new System.Windows.Forms.Label();
             this.B_RandAll = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.CHK_Type = new System.Windows.Forms.CheckBox();
             this.CHK_Category = new System.Windows.Forms.CheckBox();
+            this.CHK_Type = new System.Windows.Forms.CheckBox();
+            this.B_Metronome = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_HitMax)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_HitMin)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Priority)).BeginInit();
@@ -804,22 +805,12 @@
             // 
             this.groupBox1.Controls.Add(this.CHK_Category);
             this.groupBox1.Controls.Add(this.CHK_Type);
-            this.groupBox1.Location = new System.Drawing.Point(333, 33);
+            this.groupBox1.Location = new System.Drawing.Point(333, 60);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(98, 342);
+            this.groupBox1.Size = new System.Drawing.Size(98, 55);
             this.groupBox1.TabIndex = 64;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Options";
-            // 
-            // CHK_Type
-            // 
-            this.CHK_Type.AutoSize = true;
-            this.CHK_Type.Location = new System.Drawing.Point(6, 19);
-            this.CHK_Type.Name = "CHK_Type";
-            this.CHK_Type.Size = new System.Drawing.Size(50, 17);
-            this.CHK_Type.TabIndex = 0;
-            this.CHK_Type.Text = "Type";
-            this.CHK_Type.UseVisualStyleBackColor = true;
             // 
             // CHK_Category
             // 
@@ -831,11 +822,32 @@
             this.CHK_Category.Text = "Category";
             this.CHK_Category.UseVisualStyleBackColor = true;
             // 
-            // Moves
+            // CHK_Type
+            // 
+            this.CHK_Type.AutoSize = true;
+            this.CHK_Type.Location = new System.Drawing.Point(6, 19);
+            this.CHK_Type.Name = "CHK_Type";
+            this.CHK_Type.Size = new System.Drawing.Size(50, 17);
+            this.CHK_Type.TabIndex = 0;
+            this.CHK_Type.Text = "Type";
+            this.CHK_Type.UseVisualStyleBackColor = true;
+            // 
+            // B_Metronome
+            // 
+            this.B_Metronome.Location = new System.Drawing.Point(333, 33);
+            this.B_Metronome.Name = "B_Metronome";
+            this.B_Metronome.Size = new System.Drawing.Size(98, 23);
+            this.B_Metronome.TabIndex = 65;
+            this.B_Metronome.Text = "Metronome Mode";
+            this.B_Metronome.UseVisualStyleBackColor = true;
+            this.B_Metronome.Click += new System.EventHandler(this.B_Metronome_Click);
+            // 
+            // MoveEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(439, 382);
+            this.ClientSize = new System.Drawing.Size(439, 381);
+            this.Controls.Add(this.B_Metronome);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.B_RandAll);
             this.Controls.Add(this.L_0x21);
@@ -991,5 +1003,6 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox CHK_Category;
         private System.Windows.Forms.CheckBox CHK_Type;
+        private System.Windows.Forms.Button B_Metronome;
     }
 }

--- a/pk3DS/Subforms/Gen6/MoveEditor6.cs
+++ b/pk3DS/Subforms/Gen6/MoveEditor6.cs
@@ -10,8 +10,6 @@ namespace pk3DS
         {
             files = infiles;
             movelist[0] = "";
-            sortedmoves = (string[])movelist.Clone();
-            Array.Sort(sortedmoves);
 
             InitializeComponent();
             Setup();
@@ -21,7 +19,6 @@ namespace pk3DS
         private readonly string[] types = Main.Config.getText(TextName.Types);
         private readonly string[] moveflavor = Main.Config.getText(TextName.MoveFlavor);
         private readonly string[] movelist = Main.Config.getText(TextName.MoveNames);
-        private readonly string[] sortedmoves;
         private readonly string[] MoveCategories = { "Status", "Physical", "Special", };
         private readonly string[] StatCategories = { "None", "Attack", "Defense", "Special Attack", "Special Defense", "Speed", "Accuracy", "Evasion", "All", };
 
@@ -48,7 +45,7 @@ namespace pk3DS
             "Affect One Side of the Field", "Forces Target to Switch", "Unique Effect",  };
         private void Setup()
         {
-            foreach (string s in sortedmoves) CB_Move.Items.Add(s);
+            foreach (string s in movelist) CB_Move.Items.Add(s);
             foreach (string s in types) CB_Type.Items.Add(s);
             foreach (string s in MoveCategories) CB_Category.Items.Add(s);
             foreach (string s in StatCategories) CB_Stat1.Items.Add(s);
@@ -191,6 +188,21 @@ namespace pk3DS
                     CB_Type.SelectedIndex = rnd.Next(0, 18);
             }
             WinFormsUtil.Alert("All Moves have been randomized!");
+        }
+        private void B_Metronome_Click(object sender, EventArgs e)
+        {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Play using Metronome Mode?", "This will set the Base PP for every other Move to 0!") != DialogResult.Yes) return;
+
+            for (int i = 0; i < CB_Move.Items.Count; i++)
+            {
+                CB_Move.SelectedIndex = i;
+                if (CB_Move.SelectedIndex != 117)
+                    NUD_PP.Value = 0;
+                if (CB_Move.SelectedIndex == 117)
+                    NUD_PP.Value = 40;
+            }
+            CB_Move.SelectedIndex = 0;
+            WinFormsUtil.Alert("All Moves have had their Base PP values modified!");
         }
     }
 }

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
@@ -102,7 +102,7 @@
             this.L_ORASTutors = new System.Windows.Forms.Label();
             this.L_Special = new System.Windows.Forms.Label();
             this.L_TMHM = new System.Windows.Forms.Label();
-            this.CLB_OrasTutors = new System.Windows.Forms.CheckedListBox();
+            this.CLB_ORASTutors = new System.Windows.Forms.CheckedListBox();
             this.CLB_MoveTutors = new System.Windows.Forms.CheckedListBox();
             this.CLB_TMHM = new System.Windows.Forms.CheckedListBox();
             this.TP_Randomizer = new System.Windows.Forms.TabPage();
@@ -118,6 +118,7 @@
             this.CHK_NoEV = new System.Windows.Forms.CheckBox();
             this.B_ModAll = new System.Windows.Forms.Button();
             this.GB_Randomizer = new System.Windows.Forms.GroupBox();
+            this.CHK_Shuffle = new System.Windows.Forms.CheckBox();
             this.L_Same = new System.Windows.Forms.Label();
             this.NUD_Egg = new System.Windows.Forms.NumericUpDown();
             this.CHK_WGuard = new System.Windows.Forms.CheckBox();
@@ -144,7 +145,7 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
-            this.CHK_Shuffle = new System.Windows.Forms.CheckBox();
+            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -927,7 +928,7 @@
             this.TP_MoveTutors.Controls.Add(this.L_ORASTutors);
             this.TP_MoveTutors.Controls.Add(this.L_Special);
             this.TP_MoveTutors.Controls.Add(this.L_TMHM);
-            this.TP_MoveTutors.Controls.Add(this.CLB_OrasTutors);
+            this.TP_MoveTutors.Controls.Add(this.CLB_ORASTutors);
             this.TP_MoveTutors.Controls.Add(this.CLB_MoveTutors);
             this.TP_MoveTutors.Controls.Add(this.CLB_TMHM);
             this.TP_MoveTutors.Location = new System.Drawing.Point(4, 22);
@@ -966,17 +967,17 @@
             this.L_TMHM.TabIndex = 5;
             this.L_TMHM.Text = "TM/HM:";
             // 
-            // CLB_OrasTutors
+            // CLB_ORASTutors
             // 
-            this.CLB_OrasTutors.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.CLB_ORASTutors.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.CLB_OrasTutors.Enabled = false;
-            this.CLB_OrasTutors.FormattingEnabled = true;
-            this.CLB_OrasTutors.Location = new System.Drawing.Point(301, 19);
-            this.CLB_OrasTutors.Name = "CLB_OrasTutors";
-            this.CLB_OrasTutors.Size = new System.Drawing.Size(133, 319);
-            this.CLB_OrasTutors.TabIndex = 4;
-            this.CLB_OrasTutors.Visible = false;
+            this.CLB_ORASTutors.Enabled = false;
+            this.CLB_ORASTutors.FormattingEnabled = true;
+            this.CLB_ORASTutors.Location = new System.Drawing.Point(301, 19);
+            this.CLB_ORASTutors.Name = "CLB_ORASTutors";
+            this.CLB_ORASTutors.Size = new System.Drawing.Size(133, 319);
+            this.CLB_ORASTutors.TabIndex = 4;
+            this.CLB_ORASTutors.Visible = false;
             // 
             // CLB_MoveTutors
             // 
@@ -1013,6 +1014,7 @@
             // 
             // GB_Modifier
             // 
+            this.GB_Modifier.Controls.Add(this.CHK_NoTutor);
             this.GB_Modifier.Controls.Add(this.CHK_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.L_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.NUD_CatchRateMod);
@@ -1180,6 +1182,18 @@
             this.GB_Randomizer.TabIndex = 418;
             this.GB_Randomizer.TabStop = false;
             this.GB_Randomizer.Text = "Randomizer Options";
+            // 
+            // CHK_Shuffle
+            // 
+            this.CHK_Shuffle.AutoSize = true;
+            this.CHK_Shuffle.Checked = true;
+            this.CHK_Shuffle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_Shuffle.Location = new System.Drawing.Point(6, 75);
+            this.CHK_Shuffle.Name = "CHK_Shuffle";
+            this.CHK_Shuffle.Size = new System.Drawing.Size(86, 17);
+            this.CHK_Shuffle.TabIndex = 24;
+            this.CHK_Shuffle.Text = "Shuffle Stats";
+            this.CHK_Shuffle.UseVisualStyleBackColor = true;
             // 
             // L_Same
             // 
@@ -1476,17 +1490,15 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
-            // CHK_Shuffle
+            // CHK_NoTutor
             // 
-            this.CHK_Shuffle.AutoSize = true;
-            this.CHK_Shuffle.Checked = true;
-            this.CHK_Shuffle.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Shuffle.Location = new System.Drawing.Point(6, 75);
-            this.CHK_Shuffle.Name = "CHK_Shuffle";
-            this.CHK_Shuffle.Size = new System.Drawing.Size(86, 17);
-            this.CHK_Shuffle.TabIndex = 24;
-            this.CHK_Shuffle.Text = "Shuffle Stats";
-            this.CHK_Shuffle.UseVisualStyleBackColor = true;
+            this.CHK_NoTutor.AutoSize = true;
+            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
+            this.CHK_NoTutor.Name = "CHK_NoTutor";
+            this.CHK_NoTutor.Size = new System.Drawing.Size(212, 17);
+            this.CHK_NoTutor.TabIndex = 20;
+            this.CHK_NoTutor.Text = "Remove All TM/HM/Tutor Compatibility";
+            this.CHK_NoTutor.UseVisualStyleBackColor = true;
             // 
             // PersonalEditor6
             // 
@@ -1600,7 +1612,7 @@
         private System.Windows.Forms.Label L_BST;
 		private System.Windows.Forms.TextBox TB_BST;
         private System.Windows.Forms.CheckedListBox CLB_TMHM;
-        private System.Windows.Forms.CheckedListBox CLB_OrasTutors;
+        private System.Windows.Forms.CheckedListBox CLB_ORASTutors;
         private System.Windows.Forms.CheckedListBox CLB_MoveTutors;
         private System.Windows.Forms.Label L_ORASTutors;
         private System.Windows.Forms.Label L_Special;
@@ -1645,5 +1657,6 @@
         private System.Windows.Forms.Label L_CatchRateMod;
         private System.Windows.Forms.NumericUpDown NUD_CatchRateMod;
         private System.Windows.Forms.CheckBox CHK_Shuffle;
+        private System.Windows.Forms.CheckBox CHK_NoTutor;
     }
 }

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.cs
@@ -119,8 +119,8 @@ namespace pk3DS
                 Array.Copy(species, temp_species, temp_species.Length);
                 species = temp_species;
 
-                CLB_OrasTutors.Visible =
-                CLB_OrasTutors.Enabled =
+                CLB_ORASTutors.Visible =
+                CLB_ORASTutors.Enabled =
                 L_ORASTutors.Visible = false;
                 CHK_ORASTutors.Visible = false;
             }
@@ -128,16 +128,16 @@ namespace pk3DS
             {
                 CLB_MoveTutors.Items.Add(moves[tutormoves[tutormoves.Length - 1]]); //Dragon's Ascent
                 foreach (ushort tm in tutor1)
-                    CLB_OrasTutors.Items.Add(moves[tm]);
+                    CLB_ORASTutors.Items.Add(moves[tm]);
                 foreach (ushort tm in tutor2)
-                    CLB_OrasTutors.Items.Add(moves[tm]);
+                    CLB_ORASTutors.Items.Add(moves[tm]);
                 foreach (ushort tm in tutor3)
-                    CLB_OrasTutors.Items.Add(moves[tm]);
+                    CLB_ORASTutors.Items.Add(moves[tm]);
                 foreach (ushort tm in tutor4)
-                    CLB_OrasTutors.Items.Add(moves[tm]);
+                    CLB_ORASTutors.Items.Add(moves[tm]);
 
-                CLB_OrasTutors.Visible = 
-                CLB_OrasTutors.Enabled = 
+                CLB_ORASTutors.Visible = 
+                CLB_ORASTutors.Enabled = 
                 L_ORASTutors.Visible = true;
             }
             for (int i = 0; i < species.Length; i++)
@@ -248,7 +248,7 @@ namespace pk3DS
                 int ctr = 0;
                 for (int i = 0; i < len.Length; i++)
                     for (int b = 0; b < len[i]; b++)
-                        CLB_OrasTutors.SetItemChecked(ctr++, pkm.SpecialTutors[i][b]);
+                        CLB_ORASTutors.SetItemChecked(ctr++, pkm.SpecialTutors[i][b]);
             }
         }
         private void readEntry()
@@ -326,7 +326,7 @@ namespace pk3DS
             int ctr = 0;
             for (int i = 0; i < 4; i++)
                 for (int t = 0; t < len[i]; t++)
-                    pkm.SpecialTutors[i][t] = CLB_OrasTutors.GetItemChecked(ctr++);
+                    pkm.SpecialTutors[i][t] = CLB_ORASTutors.GetItemChecked(ctr++);
         }
         private void saveEntry()
         {
@@ -378,11 +378,22 @@ namespace pk3DS
                 if (CHK_Growth.Checked)
                     CB_EXPGroup.SelectedIndex = 5;
                 if (CHK_EXP.Checked)
-                    TB_BaseExp.Text = ((float)NUD_EXP.Value*(Convert.ToUInt16(TB_BaseExp.Text)/100f)).ToString("000");
+                    TB_BaseExp.Text = ((float)NUD_EXP.Value * (Convert.ToUInt16(TB_BaseExp.Text) / 100f)).ToString("000");
+
+                if (CHK_NoTutor.Checked)
+                {
+                    // preserve HM compatiblity to ensure story progression
+                    for (int tm = 0; tm <= 100; tm++)
+                        CLB_TMHM.SetItemCheckState(tm, CheckState.Unchecked);
+                    foreach (int mt in CLB_MoveTutors.CheckedIndices)
+                        CLB_MoveTutors.SetItemCheckState(mt, CheckState.Unchecked);
+                    foreach (int ao in CLB_ORASTutors.CheckedIndices)
+                        CLB_ORASTutors.SetItemCheckState(ao, CheckState.Unchecked);
+                }
 
                 if (CHK_QuickHatch.Checked)
                     TB_HatchCycles.Text = 1.ToString();
-                if(CHK_CatchRateMod.Checked)
+                if (CHK_CatchRateMod.Checked)
                     TB_CatchRate.Text = ((int)NUD_CatchRateMod.Value).ToString();
             }
             CB_Species.SelectedIndex = 1;

--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -520,7 +520,7 @@ namespace pk3DS
             readFile();
         }
 
-        public static bool rPKM, rSmart, rLevel, rMove, rNoMove, rForceHighPower, rAbility, rDiffAI, 
+        public static bool rPKM, rSmart, rLevel, rMove, rMetronome, rNoMove, rForceHighPower, rAbility, rDiffAI, 
             rDiffIV, rClass, rGift, rItem, rDoRand, rRandomMegas, rGymE4Only,
             rTypeTheme, rTypeGymTrainers, rOnlySingles, rDMG, rSTAB, r6PKM, rForceFullyEvolved;
         public static bool rNoFixedDamage;
@@ -539,7 +539,7 @@ namespace pk3DS
         public static decimal rGiftPercent, rLevelMultiplier, rForceFullyEvolvedLevel, rForceHighPowerLevel;
         private void B_Randomize_Click(object sender, EventArgs e)
         {
-            rPKM = rMove = rAbility = rDiffAI = rDiffIV = rClass = rGift = rItem = rDoRand = false; // init to false
+            rPKM = rMove = rMetronome = rAbility = rDiffAI = rDiffIV = rClass = rGift = rItem = rDoRand = false; // init to false
             rGiftPercent = 0;
             rForceFullyEvolvedLevel = 0;
             new TrainerRand().ShowDialog(); // Open Randomizer Config to get config vals
@@ -708,8 +708,16 @@ namespace pk3DS
                         pk.Moves[m] = (ushort)pkMoves[m];
                 }
 
+                if (rMetronome)
+                {
+                    t.Moves = true;
+                    var pkMoves = new[] { 118, 0, 0, 0 };
+                    for (int m = 0; m < 4; m++)
+                        pk.Moves[m] = (ushort)pkMoves[m];
+                }
+
                 // high-power attacks
-                if (rForceHighPower && pk.Level >= rForceHighPowerLevel)
+                if (rForceHighPower && pk.Level >= rForceHighPowerLevel && !rMetronome)
                 {
                     var pkMoves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
                     for (int m = 0; m < 4; m++)

--- a/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.Designer.cs
@@ -584,7 +584,8 @@
             this.CB_Moves.Items.AddRange(new object[] {
             "Don\'t Modify",
             "Randomize All",
-            "Use Levelup Only"});
+            "Use Levelup Only",
+            "Metronome Mode"});
             this.CB_Moves.Location = new System.Drawing.Point(67, 223);
             this.CB_Moves.Name = "CB_Moves";
             this.CB_Moves.Size = new System.Drawing.Size(135, 21);

--- a/pk3DS/Subforms/Gen6/TrainerRand.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.cs
@@ -41,6 +41,7 @@ namespace pk3DS
 
             RSTE.rMove = CB_Moves.SelectedIndex == 1;
             RSTE.rNoMove = CB_Moves.SelectedIndex == 2;
+            RSTE.rMetronome = CB_Moves.SelectedIndex == 3;
             if (RSTE.rMove)
             {
                 RSTE.rDMG = CHK_Damage.Checked;

--- a/pk3DS/Subforms/Gen7/MoveEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/MoveEditor7.Designer.cs
@@ -90,8 +90,9 @@
             this.L_0x21 = new System.Windows.Forms.Label();
             this.B_RandAll = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.CHK_Type = new System.Windows.Forms.CheckBox();
             this.CHK_Category = new System.Windows.Forms.CheckBox();
+            this.CHK_Type = new System.Windows.Forms.CheckBox();
+            this.B_Metronome = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_HitMax)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_HitMin)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Priority)).BeginInit();
@@ -804,22 +805,12 @@
             // 
             this.groupBox1.Controls.Add(this.CHK_Category);
             this.groupBox1.Controls.Add(this.CHK_Type);
-            this.groupBox1.Location = new System.Drawing.Point(333, 33);
+            this.groupBox1.Location = new System.Drawing.Point(333, 60);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(98, 342);
+            this.groupBox1.Size = new System.Drawing.Size(98, 55);
             this.groupBox1.TabIndex = 64;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Options";
-            // 
-            // CHK_Type
-            // 
-            this.CHK_Type.AutoSize = true;
-            this.CHK_Type.Location = new System.Drawing.Point(6, 19);
-            this.CHK_Type.Name = "CHK_Type";
-            this.CHK_Type.Size = new System.Drawing.Size(50, 17);
-            this.CHK_Type.TabIndex = 0;
-            this.CHK_Type.Text = "Type";
-            this.CHK_Type.UseVisualStyleBackColor = true;
             // 
             // CHK_Category
             // 
@@ -831,11 +822,32 @@
             this.CHK_Category.Text = "Category";
             this.CHK_Category.UseVisualStyleBackColor = true;
             // 
-            // Moves
+            // CHK_Type
+            // 
+            this.CHK_Type.AutoSize = true;
+            this.CHK_Type.Location = new System.Drawing.Point(6, 19);
+            this.CHK_Type.Name = "CHK_Type";
+            this.CHK_Type.Size = new System.Drawing.Size(50, 17);
+            this.CHK_Type.TabIndex = 0;
+            this.CHK_Type.Text = "Type";
+            this.CHK_Type.UseVisualStyleBackColor = true;
+            // 
+            // B_Metronome
+            // 
+            this.B_Metronome.Location = new System.Drawing.Point(333, 33);
+            this.B_Metronome.Name = "B_Metronome";
+            this.B_Metronome.Size = new System.Drawing.Size(98, 23);
+            this.B_Metronome.TabIndex = 66;
+            this.B_Metronome.Text = "Metronome Mode";
+            this.B_Metronome.UseVisualStyleBackColor = true;
+            this.B_Metronome.Click += new System.EventHandler(this.B_Metronome_Click);
+            // 
+            // MoveEditor7
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(439, 382);
+            this.ClientSize = new System.Drawing.Size(439, 381);
+            this.Controls.Add(this.B_Metronome);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.B_RandAll);
             this.Controls.Add(this.L_0x21);
@@ -889,7 +901,7 @@
             this.MaximizeBox = false;
             this.MaximumSize = new System.Drawing.Size(455, 420);
             this.MinimumSize = new System.Drawing.Size(355, 420);
-            this.Name = "MoveEditor6";
+            this.Name = "MoveEditor7";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Move Editor";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.formClosing);
@@ -991,5 +1003,6 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox CHK_Category;
         private System.Windows.Forms.CheckBox CHK_Type;
+        private System.Windows.Forms.Button B_Metronome;
     }
 }

--- a/pk3DS/Subforms/Gen7/MoveEditor7.cs
+++ b/pk3DS/Subforms/Gen7/MoveEditor7.cs
@@ -9,10 +9,7 @@ namespace pk3DS
         public MoveEditor7(byte[][] infiles)
         {
             files = infiles;
-
             movelist[0] = "";
-            sortedmoves = (string[])movelist.Clone();
-            Array.Sort(sortedmoves);
 
             InitializeComponent();
             Setup();
@@ -22,7 +19,6 @@ namespace pk3DS
         private readonly string[] types = Main.Config.getText(TextName.Types);
         private readonly string[] moveflavor = Main.Config.getText(TextName.MoveFlavor);
         private readonly string[] movelist = Main.Config.getText(TextName.MoveNames);
-        private readonly string[] sortedmoves;
         private readonly string[] MoveCategories = { "Status", "Physical", "Special", };
         private readonly string[] StatCategories = { "None", "Attack", "Defense", "Special Attack", "Special Defense", "Speed", "Accuracy", "Evasion", "All", };
 
@@ -49,7 +45,7 @@ namespace pk3DS
             "Affect One Side of the Field", "Forces Target to Switch", "Unique Effect",  };
         private void Setup()
         {
-            foreach (string s in sortedmoves) CB_Move.Items.Add(s);
+            foreach (string s in movelist) CB_Move.Items.Add(s);
             foreach (string s in types) CB_Type.Items.Add(s);
             foreach (string s in MoveCategories) CB_Category.Items.Add(s);
             foreach (string s in StatCategories) CB_Stat1.Items.Add(s);
@@ -192,6 +188,21 @@ namespace pk3DS
                     CB_Type.SelectedIndex = rnd.Next(0, 18);
             }
             WinFormsUtil.Alert("All Moves have been randomized!");
+        }
+        private void B_Metronome_Click(object sender, EventArgs e)
+        {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Play using Metronome Mode?", "This will set the Base PP for every other Move to 0!") != DialogResult.Yes) return;
+
+            for (int i = 0; i < CB_Move.Items.Count; i++)
+            {
+                CB_Move.SelectedIndex = i;
+                if (CB_Move.SelectedIndex != 117)
+                    NUD_PP.Value = 0;
+                if (CB_Move.SelectedIndex == 117)
+                    NUD_PP.Value = 40;
+            }
+            CB_Move.SelectedIndex = 0;
+            WinFormsUtil.Alert("All Moves have had their Base PP values modified!");
         }
     }
 }

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
@@ -130,9 +130,10 @@
             this.CHK_NoEV = new System.Windows.Forms.CheckBox();
             this.B_ModAll = new System.Windows.Forms.Button();
             this.GB_Randomizer = new System.Windows.Forms.GroupBox();
-            this.CHK_BeachTutors = new System.Windows.Forms.CheckBox();
+            this.CHK_Shuffle = new System.Windows.Forms.CheckBox();
             this.L_Same = new System.Windows.Forms.Label();
             this.NUD_Egg = new System.Windows.Forms.NumericUpDown();
+            this.CHK_BeachTutors = new System.Windows.Forms.CheckBox();
             this.CHK_WGuard = new System.Windows.Forms.CheckBox();
             this.CHK_Ability = new System.Windows.Forms.CheckBox();
             this.CHK_Tutors = new System.Windows.Forms.CheckBox();
@@ -156,7 +157,7 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
-            this.CHK_Shuffle = new System.Windows.Forms.CheckBox();
+            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -1118,6 +1119,7 @@
             // 
             // GB_Modifier
             // 
+            this.GB_Modifier.Controls.Add(this.CHK_NoTutor);
             this.GB_Modifier.Controls.Add(this.CHK_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.L_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.NUD_CatchRateMod);
@@ -1325,17 +1327,17 @@
             this.GB_Randomizer.TabStop = false;
             this.GB_Randomizer.Text = "Randomizer Options";
             // 
-            // CHK_BeachTutors
+            // CHK_Shuffle
             // 
-            this.CHK_BeachTutors.AutoSize = true;
-            this.CHK_BeachTutors.Checked = true;
-            this.CHK_BeachTutors.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_BeachTutors.Location = new System.Drawing.Point(219, 46);
-            this.CHK_BeachTutors.Name = "CHK_BeachTutors";
-            this.CHK_BeachTutors.Size = new System.Drawing.Size(90, 17);
-            this.CHK_BeachTutors.TabIndex = 24;
-            this.CHK_BeachTutors.Text = "Beach Tutors";
-            this.CHK_BeachTutors.UseVisualStyleBackColor = true;
+            this.CHK_Shuffle.AutoSize = true;
+            this.CHK_Shuffle.Checked = true;
+            this.CHK_Shuffle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_Shuffle.Location = new System.Drawing.Point(6, 75);
+            this.CHK_Shuffle.Name = "CHK_Shuffle";
+            this.CHK_Shuffle.Size = new System.Drawing.Size(86, 17);
+            this.CHK_Shuffle.TabIndex = 25;
+            this.CHK_Shuffle.Text = "Shuffle Stats";
+            this.CHK_Shuffle.UseVisualStyleBackColor = true;
             // 
             // L_Same
             // 
@@ -1357,6 +1359,18 @@
             0,
             0,
             0});
+            // 
+            // CHK_BeachTutors
+            // 
+            this.CHK_BeachTutors.AutoSize = true;
+            this.CHK_BeachTutors.Checked = true;
+            this.CHK_BeachTutors.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_BeachTutors.Location = new System.Drawing.Point(219, 46);
+            this.CHK_BeachTutors.Name = "CHK_BeachTutors";
+            this.CHK_BeachTutors.Size = new System.Drawing.Size(90, 17);
+            this.CHK_BeachTutors.TabIndex = 24;
+            this.CHK_BeachTutors.Text = "Beach Tutors";
+            this.CHK_BeachTutors.UseVisualStyleBackColor = true;
             // 
             // CHK_WGuard
             // 
@@ -1620,17 +1634,15 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
-            // CHK_Shuffle
+            // CHK_NoTutor
             // 
-            this.CHK_Shuffle.AutoSize = true;
-            this.CHK_Shuffle.Checked = true;
-            this.CHK_Shuffle.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Shuffle.Location = new System.Drawing.Point(6, 75);
-            this.CHK_Shuffle.Name = "CHK_Shuffle";
-            this.CHK_Shuffle.Size = new System.Drawing.Size(86, 17);
-            this.CHK_Shuffle.TabIndex = 25;
-            this.CHK_Shuffle.Text = "Shuffle Stats";
-            this.CHK_Shuffle.UseVisualStyleBackColor = true;
+            this.CHK_NoTutor.AutoSize = true;
+            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
+            this.CHK_NoTutor.Name = "CHK_NoTutor";
+            this.CHK_NoTutor.Size = new System.Drawing.Size(190, 17);
+            this.CHK_NoTutor.TabIndex = 21;
+            this.CHK_NoTutor.Text = "Remove All TM/Tutor Compatibility";
+            this.CHK_NoTutor.UseVisualStyleBackColor = true;
             // 
             // PersonalEditor7
             // 
@@ -1802,5 +1814,6 @@
         private System.Windows.Forms.CheckedListBox CLB_BeachTutors;
         private System.Windows.Forms.CheckBox CHK_BeachTutors;
         private System.Windows.Forms.CheckBox CHK_Shuffle;
+        private System.Windows.Forms.CheckBox CHK_NoTutor;
     }
 }

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.cs
@@ -362,7 +362,17 @@ namespace pk3DS
                 if (CHK_Growth.Checked)
                     CB_EXPGroup.SelectedIndex = 5;
                 if (CHK_EXP.Checked)
-                    TB_BaseExp.Text = ((float)NUD_EXP.Value*(Convert.ToUInt16(TB_BaseExp.Text)/100f)).ToString("000");
+                    TB_BaseExp.Text = ((float)NUD_EXP.Value * (Convert.ToUInt16(TB_BaseExp.Text) / 100f)).ToString("000");
+
+                if (CHK_NoTutor.Checked)
+                {
+                    foreach (int tm in CLB_TM.CheckedIndices)
+                        CLB_TM.SetItemCheckState(tm, CheckState.Unchecked);
+                    foreach (int mt in CLB_MoveTutors.CheckedIndices)
+                        CLB_MoveTutors.SetItemCheckState(mt, CheckState.Unchecked);
+                    foreach (int ao in CLB_BeachTutors.CheckedIndices)
+                        CLB_BeachTutors.SetItemCheckState(ao, CheckState.Unchecked);
+                }
 
                 if (CHK_QuickHatch.Checked)
                     TB_HatchCycles.Text = 1.ToString();

--- a/pk3DS/Subforms/Gen7/SMTE.Designer.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.Designer.cs
@@ -1906,7 +1906,8 @@
             this.CB_Moves.Items.AddRange(new object[] {
             "Don\'t Modify",
             "Randomize All",
-            "Use Levelup Only"});
+            "Use Levelup Only",
+            "Metronome Mode"});
             this.CB_Moves.Location = new System.Drawing.Point(52, 4);
             this.CB_Moves.Name = "CB_Moves";
             this.CB_Moves.Size = new System.Drawing.Size(135, 21);

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -730,10 +730,13 @@ namespace pk3DS
                         case 2: // Current LevelUp
                             pk.Moves = learn.GetCurrentMoves(pk.Species, pk.Form, pk.Level, 4);
                             break;
+                        case 3:
+                            pk.Moves = new[] { 118, 0, 0, 0 };
+                            break;
                     }
 
                     // high-power attacks
-                    if (CHK_ForceHighPower.Checked && pk.Level >= NUD_ForceHighPower.Value)
+                    if (CHK_ForceHighPower.Checked && pk.Level >= NUD_ForceHighPower.Value && CB_Moves.SelectedIndex != 3)
                         pk.Moves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
 
                     // sanitize moves

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
@@ -134,16 +134,21 @@
             this.NUD_TLevel = new System.Windows.Forms.NumericUpDown();
             this.LB_Trade = new System.Windows.Forms.ListBox();
             this.Tab_Randomizer = new System.Windows.Forms.TabPage();
+            this.GB_Tweak = new System.Windows.Forms.GroupBox();
+            this.CHK_RemoveShinyLock = new System.Windows.Forms.CheckBox();
+            this.NUD_ForceFullyEvolved = new System.Windows.Forms.NumericUpDown();
+            this.CHK_ForceTotem = new System.Windows.Forms.CheckBox();
+            this.CHK_ForceFullyEvolved = new System.Windows.Forms.CheckBox();
+            this.CHK_BasicStarter = new System.Windows.Forms.CheckBox();
+            this.CHK_ReplaceLegend = new System.Windows.Forms.CheckBox();
             this.B_ModifyLevel = new System.Windows.Forms.Button();
             this.NUD_LevelBoost = new System.Windows.Forms.NumericUpDown();
             this.CHK_Level = new System.Windows.Forms.CheckBox();
             this.B_RandAll = new System.Windows.Forms.Button();
             this.GB_Rand = new System.Windows.Forms.GroupBox();
-            this.CHK_ReplaceLegend = new System.Windows.Forms.CheckBox();
-            this.CHK_RandomAbility = new System.Windows.Forms.CheckBox();
             this.CHK_SpecialMove = new System.Windows.Forms.CheckBox();
+            this.CHK_RandomAbility = new System.Windows.Forms.CheckBox();
             this.CHK_RandomAura = new System.Windows.Forms.CheckBox();
-            this.CHK_RemoveShinyLock = new System.Windows.Forms.CheckBox();
             this.CHK_AllowMega = new System.Windows.Forms.CheckBox();
             this.CHK_Item = new System.Windows.Forms.CheckBox();
             this.CHK_G7 = new System.Windows.Forms.CheckBox();
@@ -159,11 +164,7 @@
             this.B_Starters = new System.Windows.Forms.Button();
             this.B_Save = new System.Windows.Forms.Button();
             this.B_Cancel = new System.Windows.Forms.Button();
-            this.GB_Tweak = new System.Windows.Forms.GroupBox();
-            this.CHK_BasicStarter = new System.Windows.Forms.CheckBox();
-            this.CHK_ForceTotem = new System.Windows.Forms.CheckBox();
-            this.NUD_ForceFullyEvolved = new System.Windows.Forms.NumericUpDown();
-            this.CHK_ForceFullyEvolved = new System.Windows.Forms.CheckBox();
+            this.CHK_Metronome = new System.Windows.Forms.CheckBox();
             this.TC_Tabs.SuspendLayout();
             this.Tab_Gifts.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_GForm)).BeginInit();
@@ -200,10 +201,10 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_TForm)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_TLevel)).BeginInit();
             this.Tab_Randomizer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).BeginInit();
-            this.GB_Rand.SuspendLayout();
             this.GB_Tweak.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).BeginInit();
+            this.GB_Rand.SuspendLayout();
             this.SuspendLayout();
             // 
             // TC_Tabs
@@ -1525,6 +1526,96 @@
             this.Tab_Randomizer.Text = "Randomizer Options";
             this.Tab_Randomizer.UseVisualStyleBackColor = true;
             // 
+            // GB_Tweak
+            // 
+            this.GB_Tweak.Controls.Add(this.CHK_Metronome);
+            this.GB_Tweak.Controls.Add(this.CHK_RemoveShinyLock);
+            this.GB_Tweak.Controls.Add(this.NUD_ForceFullyEvolved);
+            this.GB_Tweak.Controls.Add(this.CHK_ForceTotem);
+            this.GB_Tweak.Controls.Add(this.CHK_ForceFullyEvolved);
+            this.GB_Tweak.Controls.Add(this.CHK_BasicStarter);
+            this.GB_Tweak.Controls.Add(this.CHK_ReplaceLegend);
+            this.GB_Tweak.Location = new System.Drawing.Point(119, 245);
+            this.GB_Tweak.Name = "GB_Tweak";
+            this.GB_Tweak.Size = new System.Drawing.Size(258, 115);
+            this.GB_Tweak.TabIndex = 509;
+            this.GB_Tweak.TabStop = false;
+            this.GB_Tweak.Text = "Extra Tweaks";
+            // 
+            // CHK_RemoveShinyLock
+            // 
+            this.CHK_RemoveShinyLock.AutoSize = true;
+            this.CHK_RemoveShinyLock.Checked = true;
+            this.CHK_RemoveShinyLock.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_RemoveShinyLock.Location = new System.Drawing.Point(6, 79);
+            this.CHK_RemoveShinyLock.Name = "CHK_RemoveShinyLock";
+            this.CHK_RemoveShinyLock.Size = new System.Drawing.Size(127, 17);
+            this.CHK_RemoveShinyLock.TabIndex = 299;
+            this.CHK_RemoveShinyLock.Text = "Remove Shiny Locks";
+            this.CHK_RemoveShinyLock.UseVisualStyleBackColor = true;
+            // 
+            // NUD_ForceFullyEvolved
+            // 
+            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(165, 62);
+            this.NUD_ForceFullyEvolved.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.NUD_ForceFullyEvolved.Name = "NUD_ForceFullyEvolved";
+            this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(40, 20);
+            this.NUD_ForceFullyEvolved.TabIndex = 514;
+            this.NUD_ForceFullyEvolved.Value = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            // 
+            // CHK_ForceTotem
+            // 
+            this.CHK_ForceTotem.AutoSize = true;
+            this.CHK_ForceTotem.Location = new System.Drawing.Point(6, 47);
+            this.CHK_ForceTotem.Name = "CHK_ForceTotem";
+            this.CHK_ForceTotem.Size = new System.Drawing.Size(200, 17);
+            this.CHK_ForceTotem.TabIndex = 305;
+            this.CHK_ForceTotem.Text = "Force Fully Evolved Totem Pokémon";
+            this.CHK_ForceTotem.UseVisualStyleBackColor = true;
+            // 
+            // CHK_ForceFullyEvolved
+            // 
+            this.CHK_ForceFullyEvolved.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.CHK_ForceFullyEvolved.AutoSize = true;
+            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(6, 63);
+            this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
+            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
+            this.CHK_ForceFullyEvolved.TabIndex = 513;
+            this.CHK_ForceFullyEvolved.Text = "Force Fully Evolved at Level";
+            this.CHK_ForceFullyEvolved.UseVisualStyleBackColor = true;
+            // 
+            // CHK_BasicStarter
+            // 
+            this.CHK_BasicStarter.AutoSize = true;
+            this.CHK_BasicStarter.Checked = true;
+            this.CHK_BasicStarter.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_BasicStarter.Location = new System.Drawing.Point(6, 31);
+            this.CHK_BasicStarter.Name = "CHK_BasicStarter";
+            this.CHK_BasicStarter.Size = new System.Drawing.Size(217, 17);
+            this.CHK_BasicStarter.TabIndex = 304;
+            this.CHK_BasicStarter.Text = "Basic Starter Pokémon with 2 Evolutions";
+            this.CHK_BasicStarter.UseVisualStyleBackColor = true;
+            // 
+            // CHK_ReplaceLegend
+            // 
+            this.CHK_ReplaceLegend.AutoSize = true;
+            this.CHK_ReplaceLegend.Checked = true;
+            this.CHK_ReplaceLegend.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CHK_ReplaceLegend.Location = new System.Drawing.Point(6, 15);
+            this.CHK_ReplaceLegend.Name = "CHK_ReplaceLegend";
+            this.CHK_ReplaceLegend.Size = new System.Drawing.Size(242, 17);
+            this.CHK_ReplaceLegend.TabIndex = 303;
+            this.CHK_ReplaceLegend.Text = "Replace Legendaries with Another Legendary";
+            this.CHK_ReplaceLegend.UseVisualStyleBackColor = true;
+            // 
             // B_ModifyLevel
             // 
             this.B_ModifyLevel.Location = new System.Drawing.Point(306, 49);
@@ -1604,17 +1695,15 @@
             this.GB_Rand.TabStop = false;
             this.GB_Rand.Text = "Randomizer Options";
             // 
-            // CHK_ReplaceLegend
+            // CHK_SpecialMove
             // 
-            this.CHK_ReplaceLegend.AutoSize = true;
-            this.CHK_ReplaceLegend.Checked = true;
-            this.CHK_ReplaceLegend.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_ReplaceLegend.Location = new System.Drawing.Point(6, 15);
-            this.CHK_ReplaceLegend.Name = "CHK_ReplaceLegend";
-            this.CHK_ReplaceLegend.Size = new System.Drawing.Size(242, 17);
-            this.CHK_ReplaceLegend.TabIndex = 303;
-            this.CHK_ReplaceLegend.Text = "Replace Legendaries with Another Legendary";
-            this.CHK_ReplaceLegend.UseVisualStyleBackColor = true;
+            this.CHK_SpecialMove.AutoSize = true;
+            this.CHK_SpecialMove.Location = new System.Drawing.Point(9, 135);
+            this.CHK_SpecialMove.Name = "CHK_SpecialMove";
+            this.CHK_SpecialMove.Size = new System.Drawing.Size(197, 17);
+            this.CHK_SpecialMove.TabIndex = 301;
+            this.CHK_SpecialMove.Text = "Random Gift Move for Gift Pokémon";
+            this.CHK_SpecialMove.UseVisualStyleBackColor = true;
             // 
             // CHK_RandomAbility
             // 
@@ -1626,16 +1715,6 @@
             this.CHK_RandomAbility.Text = "Random Abilities (1, 2, or Hidden)";
             this.CHK_RandomAbility.UseVisualStyleBackColor = true;
             // 
-            // CHK_SpecialMove
-            // 
-            this.CHK_SpecialMove.AutoSize = true;
-            this.CHK_SpecialMove.Location = new System.Drawing.Point(9, 135);
-            this.CHK_SpecialMove.Name = "CHK_SpecialMove";
-            this.CHK_SpecialMove.Size = new System.Drawing.Size(197, 17);
-            this.CHK_SpecialMove.TabIndex = 301;
-            this.CHK_SpecialMove.Text = "Random Gift Move for Gift Pokémon";
-            this.CHK_SpecialMove.UseVisualStyleBackColor = true;
-            // 
             // CHK_RandomAura
             // 
             this.CHK_RandomAura.AutoSize = true;
@@ -1645,18 +1724,6 @@
             this.CHK_RandomAura.TabIndex = 300;
             this.CHK_RandomAura.Text = "Random Totem Pokémon Aura";
             this.CHK_RandomAura.UseVisualStyleBackColor = true;
-            // 
-            // CHK_RemoveShinyLock
-            // 
-            this.CHK_RemoveShinyLock.AutoSize = true;
-            this.CHK_RemoveShinyLock.Checked = true;
-            this.CHK_RemoveShinyLock.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RemoveShinyLock.Location = new System.Drawing.Point(6, 79);
-            this.CHK_RemoveShinyLock.Name = "CHK_RemoveShinyLock";
-            this.CHK_RemoveShinyLock.Size = new System.Drawing.Size(127, 17);
-            this.CHK_RemoveShinyLock.TabIndex = 299;
-            this.CHK_RemoveShinyLock.Text = "Remove Shiny Locks";
-            this.CHK_RemoveShinyLock.UseVisualStyleBackColor = true;
             // 
             // CHK_AllowMega
             // 
@@ -1828,70 +1895,15 @@
             this.B_Cancel.UseVisualStyleBackColor = true;
             this.B_Cancel.Click += new System.EventHandler(this.B_Cancel_Click);
             // 
-            // GB_Tweak
+            // CHK_Metronome
             // 
-            this.GB_Tweak.Controls.Add(this.CHK_RemoveShinyLock);
-            this.GB_Tweak.Controls.Add(this.NUD_ForceFullyEvolved);
-            this.GB_Tweak.Controls.Add(this.CHK_ForceTotem);
-            this.GB_Tweak.Controls.Add(this.CHK_ForceFullyEvolved);
-            this.GB_Tweak.Controls.Add(this.CHK_BasicStarter);
-            this.GB_Tweak.Controls.Add(this.CHK_ReplaceLegend);
-            this.GB_Tweak.Location = new System.Drawing.Point(119, 245);
-            this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 100);
-            this.GB_Tweak.TabIndex = 509;
-            this.GB_Tweak.TabStop = false;
-            this.GB_Tweak.Text = "Extra Tweaks";
-            // 
-            // CHK_BasicStarter
-            // 
-            this.CHK_BasicStarter.AutoSize = true;
-            this.CHK_BasicStarter.Checked = true;
-            this.CHK_BasicStarter.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_BasicStarter.Location = new System.Drawing.Point(6, 31);
-            this.CHK_BasicStarter.Name = "CHK_BasicStarter";
-            this.CHK_BasicStarter.Size = new System.Drawing.Size(217, 17);
-            this.CHK_BasicStarter.TabIndex = 304;
-            this.CHK_BasicStarter.Text = "Basic Starter Pokémon with 2 Evolutions";
-            this.CHK_BasicStarter.UseVisualStyleBackColor = true;
-            // 
-            // CHK_ForceTotem
-            // 
-            this.CHK_ForceTotem.AutoSize = true;
-            this.CHK_ForceTotem.Location = new System.Drawing.Point(6, 47);
-            this.CHK_ForceTotem.Name = "CHK_ForceTotem";
-            this.CHK_ForceTotem.Size = new System.Drawing.Size(200, 17);
-            this.CHK_ForceTotem.TabIndex = 305;
-            this.CHK_ForceTotem.Text = "Force Fully Evolved Totem Pokémon";
-            this.CHK_ForceTotem.UseVisualStyleBackColor = true;
-            // 
-            // NUD_ForceFullyEvolved
-            // 
-            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(165, 62);
-            this.NUD_ForceFullyEvolved.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.NUD_ForceFullyEvolved.Name = "NUD_ForceFullyEvolved";
-            this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(40, 20);
-            this.NUD_ForceFullyEvolved.TabIndex = 514;
-            this.NUD_ForceFullyEvolved.Value = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            // 
-            // CHK_ForceFullyEvolved
-            // 
-            this.CHK_ForceFullyEvolved.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.CHK_ForceFullyEvolved.AutoSize = true;
-            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(6, 63);
-            this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
-            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
-            this.CHK_ForceFullyEvolved.TabIndex = 513;
-            this.CHK_ForceFullyEvolved.Text = "Force Fully Evolved at Level";
-            this.CHK_ForceFullyEvolved.UseVisualStyleBackColor = true;
+            this.CHK_Metronome.AutoSize = true;
+            this.CHK_Metronome.Location = new System.Drawing.Point(6, 95);
+            this.CHK_Metronome.Name = "CHK_Metronome";
+            this.CHK_Metronome.Size = new System.Drawing.Size(109, 17);
+            this.CHK_Metronome.TabIndex = 515;
+            this.CHK_Metronome.Text = "Metronome Mode";
+            this.CHK_Metronome.UseVisualStyleBackColor = true;
             // 
             // StaticEncounterEditor7
             // 
@@ -1943,12 +1955,12 @@
             ((System.ComponentModel.ISupportInitialize)(this.NUD_TLevel)).EndInit();
             this.Tab_Randomizer.ResumeLayout(false);
             this.Tab_Randomizer.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).EndInit();
-            this.GB_Rand.ResumeLayout(false);
-            this.GB_Rand.PerformLayout();
             this.GB_Tweak.ResumeLayout(false);
             this.GB_Tweak.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_ForceFullyEvolved)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_LevelBoost)).EndInit();
+            this.GB_Rand.ResumeLayout(false);
+            this.GB_Rand.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -2091,5 +2103,6 @@
         private System.Windows.Forms.CheckBox CHK_BasicStarter;
         private System.Windows.Forms.NumericUpDown NUD_ForceFullyEvolved;
         private System.Windows.Forms.CheckBox CHK_ForceFullyEvolved;
+        private System.Windows.Forms.CheckBox CHK_Metronome;
     }
 }

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -494,7 +494,7 @@ namespace pk3DS
                 if (CHK_RemoveShinyLock.Checked)
                     t.ShinyLock = false;
 
-                if (CHK_SpecialMove.Checked)
+                if (CHK_SpecialMove.Checked && !CHK_Metronome.Checked)
                 {
                     int rv = Util.rand.Next(1, CB_SpecialMove.Items.Count);
                     if (banned.Contains(rv)) continue; // disallow banned moves
@@ -556,9 +556,14 @@ namespace pk3DS
 
                 if (CHK_SpecialMove.Checked)
                 {
-                    int rv = Util.rand.Next(1, CB_SpecialMove.Items.Count);
-                    if (banned.Contains(rv)) continue; // disallow banned moves
-                    t.SpecialMove = rv;
+                    if (CHK_Metronome.Checked)
+                        t.SpecialMove = 0; // remove Surf Pikachu's special move
+                    else
+                    {
+                        int rv = Util.rand.Next(1, CB_SpecialMove.Items.Count);
+                        if (banned.Contains(rv)) continue; // disallow banned moves
+                        t.SpecialMove = rv;
+                    }
                 }
 
                 if (CHK_RandomAbility.Checked)
@@ -605,8 +610,12 @@ namespace pk3DS
                 if (CHK_ForceFullyEvolved.Checked && t.Level >= NUD_ForceFullyEvolved.Value && !FinalEvo.Contains(t.Species))
                     t.Species = FinalEvo[randFinalEvo()];
 
+                if (CHK_Metronome.Checked)
+                    t.RelearnMoves = new[] { 118, 0, 0, 0 };
+                else
+                    t.RelearnMoves = move.GetCurrentMoves(t.Species, t.Form, t.Level, 4);
+
                 t.Form = Randomizer.GetRandomForme(t.Species, CHK_AllowMega.Checked, true, Main.SpeciesStat);
-                t.RelearnMoves = move.GetCurrentMoves(t.Species, t.Form, t.Level, 4);
                 t.Gender = 0; // random
                 t.Nature = 0; // random
             }


### PR DESCRIPTION
Ideas taken from https://github.com/kwsch/pk3DS/pull/313#issuecomment-379828363, thank you!

- Add PP modifier (sets all Base PP to 0, except for Metronome which gets 40)
- Add Metronome Mode case for Trainer PKM/Gen 7 Static Encounter Moves
Note: Force High Power for RSTE/SMTE will only work if Metronome Mode is disabled!
- Add TM/Tutor compatibility removal (HM is preserved for story progression)