### PR TITLE
Quality of life changes

### DIFF
--- a/pk3DS.Core/Legality/Legal.cs
+++ b/pk3DS.Core/Legality/Legal.cs
@@ -201,7 +201,6 @@ namespace pk3DS.Core
             184, // Battle Legend
             #endregion
         };
-
         public static readonly int[] SpecialClasses_USUM =
         {
             #region Classes

--- a/pk3DS/Main.Designer.cs
+++ b/pk3DS/Main.Designer.cs
@@ -138,7 +138,7 @@
             this.B_OPower.Name = "B_OPower";
             this.B_OPower.Size = new System.Drawing.Size(100, 23);
             this.B_OPower.TabIndex = 4;
-            this.B_OPower.Text = "O-Power";
+            this.B_OPower.Text = "O-Powers";
             this.B_OPower.UseVisualStyleBackColor = true;
             this.B_OPower.Click += new System.EventHandler(this.B_OPower_Click);
             // 
@@ -148,7 +148,7 @@
             this.B_Pickup.Name = "B_Pickup";
             this.B_Pickup.Size = new System.Drawing.Size(100, 23);
             this.B_Pickup.TabIndex = 0;
-            this.B_Pickup.Text = "Pickup";
+            this.B_Pickup.Text = "Pickup Items";
             this.B_Pickup.UseVisualStyleBackColor = true;
             this.B_Pickup.Click += new System.EventHandler(this.B_Pickup_Click);
             // 
@@ -309,7 +309,7 @@
             // 
             this.Menu_RomFS.Enabled = false;
             this.Menu_RomFS.Name = "Menu_RomFS";
-            this.Menu_RomFS.Size = new System.Drawing.Size(152, 22);
+            this.Menu_RomFS.Size = new System.Drawing.Size(111, 22);
             this.Menu_RomFS.Text = "RomFS";
             this.Menu_RomFS.Click += new System.EventHandler(this.rebuildRomFS);
             // 
@@ -317,7 +317,7 @@
             // 
             this.Menu_ExeFS.Enabled = false;
             this.Menu_ExeFS.Name = "Menu_ExeFS";
-            this.Menu_ExeFS.Size = new System.Drawing.Size(152, 22);
+            this.Menu_ExeFS.Size = new System.Drawing.Size(111, 22);
             this.Menu_ExeFS.Text = "ExeFS";
             this.Menu_ExeFS.Click += new System.EventHandler(this.rebuildExeFS);
             // 
@@ -325,7 +325,7 @@
             // 
             this.Menu_CRO.Enabled = false;
             this.Menu_CRO.Name = "Menu_CRO";
-            this.Menu_CRO.Size = new System.Drawing.Size(152, 22);
+            this.Menu_CRO.Size = new System.Drawing.Size(111, 22);
             this.Menu_CRO.Text = "CRO";
             this.Menu_CRO.Click += new System.EventHandler(this.patchCRO_CRR);
             // 
@@ -333,7 +333,7 @@
             // 
             this.Menu_3DS.Enabled = false;
             this.Menu_3DS.Name = "Menu_3DS";
-            this.Menu_3DS.Size = new System.Drawing.Size(152, 22);
+            this.Menu_3DS.Size = new System.Drawing.Size(111, 22);
             this.Menu_3DS.Text = ".3DS";
             this.Menu_3DS.Click += new System.EventHandler(this.B_Rebuild3DS_Click);
             // 
@@ -341,7 +341,7 @@
             // 
             this.Menu_Patch.Enabled = false;
             this.Menu_Patch.Name = "Menu_Patch";
-            this.Menu_Patch.Size = new System.Drawing.Size(152, 22);
+            this.Menu_Patch.Size = new System.Drawing.Size(111, 22);
             this.Menu_Patch.Text = "Patch";
             this.Menu_Patch.Click += new System.EventHandler(this.B_Patch_Click);
             // 
@@ -363,7 +363,7 @@
             // setInt32SeedToolStripMenuItem
             // 
             this.setInt32SeedToolStripMenuItem.Name = "setInt32SeedToolStripMenuItem";
-            this.setInt32SeedToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.setInt32SeedToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.setInt32SeedToolStripMenuItem.Text = "Set int32 seed";
             this.setInt32SeedToolStripMenuItem.Click += new System.EventHandler(this.setInt32SeedToolStripMenuItem_Click);
             // 
@@ -382,7 +382,7 @@
             this.Menu_Language.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.CB_Lang});
             this.Menu_Language.Name = "Menu_Language";
-            this.Menu_Language.Size = new System.Drawing.Size(152, 22);
+            this.Menu_Language.Size = new System.Drawing.Size(146, 22);
             this.Menu_Language.Text = "Language";
             // 
             // CB_Lang
@@ -408,14 +408,14 @@
             this.Menu_About.Name = "Menu_About";
             this.Menu_About.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
             this.Menu_About.ShowShortcutKeys = false;
-            this.Menu_About.Size = new System.Drawing.Size(152, 22);
+            this.Menu_About.Size = new System.Drawing.Size(146, 22);
             this.Menu_About.Text = "A&bout pk3DS";
             this.Menu_About.Click += new System.EventHandler(this.L_About_Click);
             // 
             // Menu_GARCs
             // 
             this.Menu_GARCs.Name = "Menu_GARCs";
-            this.Menu_GARCs.Size = new System.Drawing.Size(152, 22);
+            this.Menu_GARCs.Size = new System.Drawing.Size(146, 22);
             this.Menu_GARCs.Text = "About GARCs";
             this.Menu_GARCs.Click += new System.EventHandler(this.L_GARCInfo_Click);
             // 
@@ -705,7 +705,7 @@
             this.B_Starter.Name = "B_Starter";
             this.B_Starter.Size = new System.Drawing.Size(100, 23);
             this.B_Starter.TabIndex = 1;
-            this.B_Starter.Text = "Starters";
+            this.B_Starter.Text = "Starter Pokémon";
             this.B_Starter.UseVisualStyleBackColor = true;
             this.B_Starter.Click += new System.EventHandler(this.B_Starter_Click);
             // 

--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -639,6 +639,9 @@ namespace pk3DS
         private void B_OWSE_Click(object sender, EventArgs e)
         {
             if (threadActive()) return;
+            if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo,
+                        "The OverWorld/Script Editor is not recommended for most users and is still a work-in-progress.", "Continue anyway?"))
+                return;
             switch (Config.Generation)
             {
                 case 6:

--- a/pk3DS/Subforms/Gen6/EggMoveEditor6.cs
+++ b/pk3DS/Subforms/Gen6/EggMoveEditor6.cs
@@ -123,7 +123,7 @@ namespace pk3DS
             rand.Execute();
             sets.Select(z => z.Write()).ToArray().CopyTo(files, 0);
             getList();
-            WinFormsUtil.Alert("All Pokémon's Egg Moves have been randomized!");
+            WinFormsUtil.Alert("All Pokémon's Egg Moves have been randomized!", "Press the Dump button to see the new Egg Moves!");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen6/GiftEditor6.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.cs
@@ -231,7 +231,6 @@ namespace pk3DS
                         continue; // skip Lucario, battle needs to Mega Evolve
 
                     int[] items = GetRandomMega(out species);
-                    NUD_Form.Value = 0;
                     CB_HeldItem.SelectedIndex = items[Util.rand.Next(0, items.Length)];
                 }
                 else

--- a/pk3DS/Subforms/Gen6/LevelUpEditor6.cs
+++ b/pk3DS/Subforms/Gen6/LevelUpEditor6.cs
@@ -155,10 +155,12 @@ namespace pk3DS
             rand.Execute();
             sets.Select(z => z.Write()).ToArray().CopyTo(files, 0);
             getList();
-            WinFormsUtil.Alert("All Pokémon's Level Up Moves have been randomized!");
+            WinFormsUtil.Alert("All Pokémon's Level Up Moves have been randomized!", "Press the Dump button to see the new Level Up Moves!");
         }
         private void B_Metronome_Click(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Play using Metronome Mode?", "This will modify learnsets to only have Metronome.") != DialogResult.Yes) return;
+
             // clear all data, then only assign Metronome at Lv1
             for (int i = 0; i < CB_Species.Items.Count; i++)
             {
@@ -169,7 +171,7 @@ namespace pk3DS
                 dgv.Rows[0].Cells[1].Value = movelist[118];
             }
             CB_Species.SelectedIndex = 0;
-            WinFormsUtil.Alert("All Pokémon now only know the move Metronome!", "It is recommended that you open the Move Editor and set the Base PP for Metronome to 40.");
+            WinFormsUtil.Alert("All Pokémon now only know the move Metronome!");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
@@ -32,9 +32,11 @@
             this.L_Species_Precursor = new System.Windows.Forms.Label();
             this.TC_Pokemon = new System.Windows.Forms.TabControl();
             this.TP_General = new System.Windows.Forms.TabPage();
+            this.L_HiddenAbility = new System.Windows.Forms.Label();
+            this.L_Ability2 = new System.Windows.Forms.Label();
+            this.L_Ability1 = new System.Windows.Forms.Label();
             this.TB_BST = new System.Windows.Forms.TextBox();
             this.L_BST = new System.Windows.Forms.Label();
-            this.TB_RawColor = new System.Windows.Forms.TextBox();
             this.TB_CatchRate = new System.Windows.Forms.MaskedTextBox();
             this.TB_Stage = new System.Windows.Forms.TextBox();
             this.L_Stage = new System.Windows.Forms.Label();
@@ -107,6 +109,7 @@
             this.CLB_TMHM = new System.Windows.Forms.CheckedListBox();
             this.TP_Randomizer = new System.Windows.Forms.TabPage();
             this.GB_Modifier = new System.Windows.Forms.GroupBox();
+            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.CHK_CatchRateMod = new System.Windows.Forms.CheckBox();
             this.L_CatchRateMod = new System.Windows.Forms.Label();
             this.NUD_CatchRateMod = new System.Windows.Forms.NumericUpDown();
@@ -145,7 +148,6 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
-            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -190,14 +192,16 @@
             this.TC_Pokemon.Location = new System.Drawing.Point(12, 40);
             this.TC_Pokemon.Name = "TC_Pokemon";
             this.TC_Pokemon.SelectedIndex = 0;
-            this.TC_Pokemon.Size = new System.Drawing.Size(445, 365);
+            this.TC_Pokemon.Size = new System.Drawing.Size(445, 375);
             this.TC_Pokemon.TabIndex = 416;
             // 
             // TP_General
             // 
+            this.TP_General.Controls.Add(this.L_HiddenAbility);
+            this.TP_General.Controls.Add(this.L_Ability2);
+            this.TP_General.Controls.Add(this.L_Ability1);
             this.TP_General.Controls.Add(this.TB_BST);
             this.TP_General.Controls.Add(this.L_BST);
-            this.TP_General.Controls.Add(this.TB_RawColor);
             this.TP_General.Controls.Add(this.TB_CatchRate);
             this.TP_General.Controls.Add(this.TB_Stage);
             this.TP_General.Controls.Add(this.L_Stage);
@@ -264,10 +268,37 @@
             this.TP_General.Location = new System.Drawing.Point(4, 22);
             this.TP_General.Name = "TP_General";
             this.TP_General.Padding = new System.Windows.Forms.Padding(3);
-            this.TP_General.Size = new System.Drawing.Size(437, 339);
+            this.TP_General.Size = new System.Drawing.Size(437, 349);
             this.TP_General.TabIndex = 0;
             this.TP_General.Text = "General Info";
             this.TP_General.UseVisualStyleBackColor = true;
+            // 
+            // L_HiddenAbility
+            // 
+            this.L_HiddenAbility.AutoSize = true;
+            this.L_HiddenAbility.Location = new System.Drawing.Point(413, 126);
+            this.L_HiddenAbility.Name = "L_HiddenAbility";
+            this.L_HiddenAbility.Size = new System.Drawing.Size(21, 13);
+            this.L_HiddenAbility.TabIndex = 93;
+            this.L_HiddenAbility.Text = "(H)";
+            // 
+            // L_Ability2
+            // 
+            this.L_Ability2.AutoSize = true;
+            this.L_Ability2.Location = new System.Drawing.Point(414, 104);
+            this.L_Ability2.Name = "L_Ability2";
+            this.L_Ability2.Size = new System.Drawing.Size(19, 13);
+            this.L_Ability2.TabIndex = 92;
+            this.L_Ability2.Text = "(2)";
+            // 
+            // L_Ability1
+            // 
+            this.L_Ability1.AutoSize = true;
+            this.L_Ability1.Location = new System.Drawing.Point(414, 82);
+            this.L_Ability1.Name = "L_Ability1";
+            this.L_Ability1.Size = new System.Drawing.Size(19, 13);
+            this.L_Ability1.TabIndex = 91;
+            this.L_Ability1.Text = "(1)";
             // 
             // TB_BST
             // 
@@ -289,16 +320,6 @@
             this.L_BST.Text = "BST:";
             this.L_BST.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // TB_RawColor
-            // 
-            this.TB_RawColor.Location = new System.Drawing.Point(236, 211);
-            this.TB_RawColor.Name = "TB_RawColor";
-            this.TB_RawColor.ReadOnly = true;
-            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
-            this.TB_RawColor.TabIndex = 88;
-            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.TB_RawColor.Visible = false;
-            // 
             // TB_CatchRate
             // 
             this.TB_CatchRate.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -312,17 +333,17 @@
             // 
             // TB_Stage
             // 
-            this.TB_Stage.Location = new System.Drawing.Point(376, 248);
+            this.TB_Stage.Location = new System.Drawing.Point(384, 238);
             this.TB_Stage.Name = "TB_Stage";
             this.TB_Stage.ReadOnly = true;
-            this.TB_Stage.Size = new System.Drawing.Size(30, 20);
+            this.TB_Stage.Size = new System.Drawing.Size(32, 20);
             this.TB_Stage.TabIndex = 86;
             this.TB_Stage.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_Stage
             // 
             this.L_Stage.AutoSize = true;
-            this.L_Stage.Location = new System.Drawing.Point(290, 251);
+            this.L_Stage.Location = new System.Drawing.Point(299, 240);
             this.L_Stage.Name = "L_Stage";
             this.L_Stage.Size = new System.Drawing.Size(85, 13);
             this.L_Stage.TabIndex = 85;
@@ -332,7 +353,7 @@
             // L_WeightKG
             // 
             this.L_WeightKG.AutoSize = true;
-            this.L_WeightKG.Location = new System.Drawing.Point(269, 300);
+            this.L_WeightKG.Location = new System.Drawing.Point(416, 326);
             this.L_WeightKG.Name = "L_WeightKG";
             this.L_WeightKG.Size = new System.Drawing.Size(19, 13);
             this.L_WeightKG.TabIndex = 84;
@@ -341,7 +362,7 @@
             // L_HeightM
             // 
             this.L_HeightM.AutoSize = true;
-            this.L_HeightM.Location = new System.Drawing.Point(128, 300);
+            this.L_HeightM.Location = new System.Drawing.Point(416, 305);
             this.L_HeightM.Name = "L_HeightM";
             this.L_HeightM.Size = new System.Drawing.Size(15, 13);
             this.L_HeightM.TabIndex = 83;
@@ -349,17 +370,17 @@
             // 
             // TB_FormeCount
             // 
-            this.TB_FormeCount.Location = new System.Drawing.Point(376, 296);
+            this.TB_FormeCount.Location = new System.Drawing.Point(384, 280);
             this.TB_FormeCount.Name = "TB_FormeCount";
             this.TB_FormeCount.ReadOnly = true;
-            this.TB_FormeCount.Size = new System.Drawing.Size(30, 20);
+            this.TB_FormeCount.Size = new System.Drawing.Size(32, 20);
             this.TB_FormeCount.TabIndex = 82;
             this.TB_FormeCount.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_FormesCount
             // 
             this.L_FormesCount.AutoSize = true;
-            this.L_FormesCount.Location = new System.Drawing.Point(300, 300);
+            this.L_FormesCount.Location = new System.Drawing.Point(309, 283);
             this.L_FormesCount.Name = "L_FormesCount";
             this.L_FormesCount.Size = new System.Drawing.Size(75, 13);
             this.L_FormesCount.TabIndex = 81;
@@ -368,17 +389,17 @@
             // 
             // TB_FormeSprite
             // 
-            this.TB_FormeSprite.Location = new System.Drawing.Point(376, 272);
+            this.TB_FormeSprite.Location = new System.Drawing.Point(384, 259);
             this.TB_FormeSprite.Name = "TB_FormeSprite";
             this.TB_FormeSprite.ReadOnly = true;
-            this.TB_FormeSprite.Size = new System.Drawing.Size(30, 20);
+            this.TB_FormeSprite.Size = new System.Drawing.Size(32, 20);
             this.TB_FormeSprite.TabIndex = 80;
             this.TB_FormeSprite.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_FormeSprite
             // 
             this.L_FormeSprite.AutoSize = true;
-            this.L_FormeSprite.Location = new System.Drawing.Point(306, 276);
+            this.L_FormeSprite.Location = new System.Drawing.Point(315, 262);
             this.L_FormeSprite.Name = "L_FormeSprite";
             this.L_FormeSprite.Size = new System.Drawing.Size(69, 13);
             this.L_FormeSprite.TabIndex = 79;
@@ -399,9 +420,9 @@
             this.CB_Color.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Color.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Color.FormattingEnabled = true;
-            this.CB_Color.Location = new System.Drawing.Point(311, 211);
+            this.CB_Color.Location = new System.Drawing.Point(295, 209);
             this.CB_Color.Name = "CB_Color";
-            this.CB_Color.Size = new System.Drawing.Size(105, 21);
+            this.CB_Color.Size = new System.Drawing.Size(121, 21);
             this.CB_Color.TabIndex = 76;
             // 
             // CB_EXPGroup
@@ -417,7 +438,7 @@
             // L_Color
             // 
             this.L_Color.AutoSize = true;
-            this.L_Color.Location = new System.Drawing.Point(276, 214);
+            this.L_Color.Location = new System.Drawing.Point(261, 211);
             this.L_Color.Name = "L_Color";
             this.L_Color.Size = new System.Drawing.Size(34, 13);
             this.L_Color.TabIndex = 74;
@@ -426,7 +447,7 @@
             // L_EXPGrowth
             // 
             this.L_EXPGrowth.AutoSize = true;
-            this.L_EXPGrowth.Location = new System.Drawing.Point(16, 214);
+            this.L_EXPGrowth.Location = new System.Drawing.Point(16, 213);
             this.L_EXPGrowth.Name = "L_EXPGrowth";
             this.L_EXPGrowth.Size = new System.Drawing.Size(63, 13);
             this.L_EXPGrowth.TabIndex = 73;
@@ -435,27 +456,27 @@
             // TB_Weight
             // 
             this.TB_Weight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Weight.Location = new System.Drawing.Point(235, 296);
+            this.TB_Weight.Location = new System.Drawing.Point(384, 322);
             this.TB_Weight.Mask = "000.0";
             this.TB_Weight.Name = "TB_Weight";
-            this.TB_Weight.Size = new System.Drawing.Size(31, 20);
+            this.TB_Weight.Size = new System.Drawing.Size(32, 20);
             this.TB_Weight.TabIndex = 72;
             this.TB_Weight.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // TB_Height
             // 
             this.TB_Height.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Height.Location = new System.Drawing.Point(94, 296);
+            this.TB_Height.Location = new System.Drawing.Point(384, 301);
             this.TB_Height.Mask = "00.0";
             this.TB_Height.Name = "TB_Height";
-            this.TB_Height.Size = new System.Drawing.Size(31, 20);
+            this.TB_Height.Size = new System.Drawing.Size(32, 20);
             this.TB_Height.TabIndex = 71;
             this.TB_Height.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_Weight
             // 
             this.L_Weight.AutoSize = true;
-            this.L_Weight.Location = new System.Drawing.Point(190, 300);
+            this.L_Weight.Location = new System.Drawing.Point(340, 325);
             this.L_Weight.Name = "L_Weight";
             this.L_Weight.Size = new System.Drawing.Size(44, 13);
             this.L_Weight.TabIndex = 70;
@@ -465,7 +486,7 @@
             // L_Height
             // 
             this.L_Height.AutoSize = true;
-            this.L_Height.Location = new System.Drawing.Point(52, 300);
+            this.L_Height.Location = new System.Drawing.Point(343, 304);
             this.L_Height.Name = "L_Height";
             this.L_Height.Size = new System.Drawing.Size(41, 13);
             this.L_Height.TabIndex = 69;
@@ -477,7 +498,7 @@
             this.CB_Ability3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability3.FormattingEnabled = true;
-            this.CB_Ability3.Location = new System.Drawing.Point(276, 131);
+            this.CB_Ability3.Location = new System.Drawing.Point(272, 123);
             this.CB_Ability3.Name = "CB_Ability3";
             this.CB_Ability3.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability3.TabIndex = 68;
@@ -487,7 +508,7 @@
             this.CB_Ability2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability2.FormattingEnabled = true;
-            this.CB_Ability2.Location = new System.Drawing.Point(276, 105);
+            this.CB_Ability2.Location = new System.Drawing.Point(272, 101);
             this.CB_Ability2.Name = "CB_Ability2";
             this.CB_Ability2.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability2.TabIndex = 67;
@@ -497,7 +518,7 @@
             this.CB_Ability1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability1.FormattingEnabled = true;
-            this.CB_Ability1.Location = new System.Drawing.Point(276, 79);
+            this.CB_Ability1.Location = new System.Drawing.Point(272, 79);
             this.CB_Ability1.Name = "CB_Ability1";
             this.CB_Ability1.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability1.TabIndex = 66;
@@ -507,7 +528,7 @@
             this.CB_EggGroup2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_EggGroup2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EggGroup2.FormattingEnabled = true;
-            this.CB_EggGroup2.Location = new System.Drawing.Point(295, 184);
+            this.CB_EggGroup2.Location = new System.Drawing.Point(295, 180);
             this.CB_EggGroup2.Name = "CB_EggGroup2";
             this.CB_EggGroup2.Size = new System.Drawing.Size(121, 21);
             this.CB_EggGroup2.TabIndex = 65;
@@ -534,7 +555,7 @@
             // L_Ability
             // 
             this.L_Ability.AutoSize = true;
-            this.L_Ability.Location = new System.Drawing.Point(230, 83);
+            this.L_Ability.Location = new System.Drawing.Point(226, 83);
             this.L_Ability.Name = "L_Ability";
             this.L_Ability.Size = new System.Drawing.Size(45, 13);
             this.L_Ability.TabIndex = 62;
@@ -543,7 +564,7 @@
             // TB_BaseExp
             // 
             this.TB_BaseExp.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_BaseExp.Location = new System.Drawing.Point(235, 272);
+            this.TB_BaseExp.Location = new System.Drawing.Point(77, 302);
             this.TB_BaseExp.Mask = "000";
             this.TB_BaseExp.Name = "TB_BaseExp";
             this.TB_BaseExp.Size = new System.Drawing.Size(31, 20);
@@ -554,7 +575,7 @@
             // L_BaseEXP
             // 
             this.L_BaseEXP.AutoSize = true;
-            this.L_BaseEXP.Location = new System.Drawing.Point(176, 276);
+            this.L_BaseEXP.Location = new System.Drawing.Point(18, 306);
             this.L_BaseEXP.Name = "L_BaseEXP";
             this.L_BaseEXP.Size = new System.Drawing.Size(58, 13);
             this.L_BaseEXP.TabIndex = 60;
@@ -564,7 +585,7 @@
             // TB_HatchCycles
             // 
             this.TB_HatchCycles.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_HatchCycles.Location = new System.Drawing.Point(235, 248);
+            this.TB_HatchCycles.Location = new System.Drawing.Point(77, 323);
             this.TB_HatchCycles.Mask = "000";
             this.TB_HatchCycles.Name = "TB_HatchCycles";
             this.TB_HatchCycles.Size = new System.Drawing.Size(31, 20);
@@ -575,7 +596,7 @@
             // L_HatchCycles
             // 
             this.L_HatchCycles.AutoSize = true;
-            this.L_HatchCycles.Location = new System.Drawing.Point(161, 251);
+            this.L_HatchCycles.Location = new System.Drawing.Point(3, 326);
             this.L_HatchCycles.Name = "L_HatchCycles";
             this.L_HatchCycles.Size = new System.Drawing.Size(73, 13);
             this.L_HatchCycles.TabIndex = 57;
@@ -585,7 +606,7 @@
             // TB_Friendship
             // 
             this.TB_Friendship.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Friendship.Location = new System.Drawing.Point(94, 272);
+            this.TB_Friendship.Location = new System.Drawing.Point(77, 281);
             this.TB_Friendship.Mask = "000";
             this.TB_Friendship.Name = "TB_Friendship";
             this.TB_Friendship.Size = new System.Drawing.Size(31, 20);
@@ -596,7 +617,7 @@
             // TB_Gender
             // 
             this.TB_Gender.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Gender.Location = new System.Drawing.Point(94, 248);
+            this.TB_Gender.Location = new System.Drawing.Point(77, 260);
             this.TB_Gender.Mask = "000";
             this.TB_Gender.Name = "TB_Gender";
             this.TB_Gender.Size = new System.Drawing.Size(31, 20);
@@ -607,7 +628,7 @@
             // L_Friendship
             // 
             this.L_Friendship.AutoSize = true;
-            this.L_Friendship.Location = new System.Drawing.Point(35, 276);
+            this.L_Friendship.Location = new System.Drawing.Point(18, 285);
             this.L_Friendship.Name = "L_Friendship";
             this.L_Friendship.Size = new System.Drawing.Size(58, 13);
             this.L_Friendship.TabIndex = 54;
@@ -617,7 +638,7 @@
             // L_Gender
             // 
             this.L_Gender.AutoSize = true;
-            this.L_Gender.Location = new System.Drawing.Point(48, 251);
+            this.L_Gender.Location = new System.Drawing.Point(31, 264);
             this.L_Gender.Name = "L_Gender";
             this.L_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Gender.TabIndex = 53;
@@ -627,7 +648,7 @@
             // L_Item1
             // 
             this.L_Item1.AutoSize = true;
-            this.L_Item1.Location = new System.Drawing.Point(195, 134);
+            this.L_Item1.Location = new System.Drawing.Point(195, 126);
             this.L_Item1.Name = "L_Item1";
             this.L_Item1.Size = new System.Drawing.Size(21, 13);
             this.L_Item1.TabIndex = 52;
@@ -636,7 +657,7 @@
             // L_Item5
             // 
             this.L_Item5.AutoSize = true;
-            this.L_Item5.Location = new System.Drawing.Point(195, 107);
+            this.L_Item5.Location = new System.Drawing.Point(195, 104);
             this.L_Item5.Name = "L_Item5";
             this.L_Item5.Size = new System.Drawing.Size(21, 13);
             this.L_Item5.TabIndex = 51;
@@ -656,7 +677,7 @@
             this.CB_HeldItem3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_HeldItem3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_HeldItem3.FormattingEnabled = true;
-            this.CB_HeldItem3.Location = new System.Drawing.Point(52, 131);
+            this.CB_HeldItem3.Location = new System.Drawing.Point(52, 123);
             this.CB_HeldItem3.Name = "CB_HeldItem3";
             this.CB_HeldItem3.Size = new System.Drawing.Size(140, 21);
             this.CB_HeldItem3.TabIndex = 49;
@@ -666,7 +687,7 @@
             this.CB_HeldItem2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_HeldItem2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_HeldItem2.FormattingEnabled = true;
-            this.CB_HeldItem2.Location = new System.Drawing.Point(52, 105);
+            this.CB_HeldItem2.Location = new System.Drawing.Point(52, 101);
             this.CB_HeldItem2.Name = "CB_HeldItem2";
             this.CB_HeldItem2.Size = new System.Drawing.Size(140, 21);
             this.CB_HeldItem2.TabIndex = 48;
@@ -695,7 +716,7 @@
             this.CB_Type2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Type2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Type2.FormattingEnabled = true;
-            this.CB_Type2.Location = new System.Drawing.Point(63, 184);
+            this.CB_Type2.Location = new System.Drawing.Point(63, 180);
             this.CB_Type2.Name = "CB_Type2";
             this.CB_Type2.Size = new System.Drawing.Size(129, 21);
             this.CB_Type2.TabIndex = 45;
@@ -934,7 +955,7 @@
             this.TP_MoveTutors.Location = new System.Drawing.Point(4, 22);
             this.TP_MoveTutors.Name = "TP_MoveTutors";
             this.TP_MoveTutors.Padding = new System.Windows.Forms.Padding(3);
-            this.TP_MoveTutors.Size = new System.Drawing.Size(437, 339);
+            this.TP_MoveTutors.Size = new System.Drawing.Size(437, 349);
             this.TP_MoveTutors.TabIndex = 1;
             this.TP_MoveTutors.Text = "Move Tutors";
             this.TP_MoveTutors.UseVisualStyleBackColor = true;
@@ -963,9 +984,9 @@
             this.L_TMHM.AutoSize = true;
             this.L_TMHM.Location = new System.Drawing.Point(6, 3);
             this.L_TMHM.Name = "L_TMHM";
-            this.L_TMHM.Size = new System.Drawing.Size(48, 13);
+            this.L_TMHM.Size = new System.Drawing.Size(58, 13);
             this.L_TMHM.TabIndex = 5;
-            this.L_TMHM.Text = "TM/HM:";
+            this.L_TMHM.Text = "TMs/HMs:";
             // 
             // CLB_ORASTutors
             // 
@@ -1007,7 +1028,7 @@
             this.TP_Randomizer.Controls.Add(this.B_Randomize);
             this.TP_Randomizer.Location = new System.Drawing.Point(4, 22);
             this.TP_Randomizer.Name = "TP_Randomizer";
-            this.TP_Randomizer.Size = new System.Drawing.Size(437, 339);
+            this.TP_Randomizer.Size = new System.Drawing.Size(437, 349);
             this.TP_Randomizer.TabIndex = 2;
             this.TP_Randomizer.Text = "Enhancements";
             this.TP_Randomizer.UseVisualStyleBackColor = true;
@@ -1031,6 +1052,16 @@
             this.GB_Modifier.TabStop = false;
             this.GB_Modifier.Text = "Modifier Options";
             // 
+            // CHK_NoTutor
+            // 
+            this.CHK_NoTutor.AutoSize = true;
+            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
+            this.CHK_NoTutor.Name = "CHK_NoTutor";
+            this.CHK_NoTutor.Size = new System.Drawing.Size(176, 30);
+            this.CHK_NoTutor.TabIndex = 20;
+            this.CHK_NoTutor.Text = "Remove All TM/Move Tutor\nCompatibility (Metronome Mode)";
+            this.CHK_NoTutor.UseVisualStyleBackColor = true;
+            // 
             // CHK_CatchRateMod
             // 
             this.CHK_CatchRateMod.AutoSize = true;
@@ -1044,7 +1075,7 @@
             // L_CatchRateMod
             // 
             this.L_CatchRateMod.AutoSize = true;
-            this.L_CatchRateMod.Location = new System.Drawing.Point(204, 58);
+            this.L_CatchRateMod.Location = new System.Drawing.Point(230, 58);
             this.L_CatchRateMod.Name = "L_CatchRateMod";
             this.L_CatchRateMod.Size = new System.Drawing.Size(34, 13);
             this.L_CatchRateMod.TabIndex = 18;
@@ -1107,7 +1138,7 @@
             // L_FinalXP
             // 
             this.L_FinalXP.AutoSize = true;
-            this.L_FinalXP.Location = new System.Drawing.Point(6, 71);
+            this.L_FinalXP.Location = new System.Drawing.Point(6, 74);
             this.L_FinalXP.Name = "L_FinalXP";
             this.L_FinalXP.Size = new System.Drawing.Size(63, 13);
             this.L_FinalXP.TabIndex = 6;
@@ -1115,7 +1146,7 @@
             // 
             // NUD_EXP
             // 
-            this.NUD_EXP.Location = new System.Drawing.Point(69, 69);
+            this.NUD_EXP.Location = new System.Drawing.Point(69, 72);
             this.NUD_EXP.Maximum = new decimal(new int[] {
             300,
             0,
@@ -1178,7 +1209,7 @@
             this.GB_Randomizer.Controls.Add(this.CHK_Item);
             this.GB_Randomizer.Location = new System.Drawing.Point(4, 12);
             this.GB_Randomizer.Name = "GB_Randomizer";
-            this.GB_Randomizer.Size = new System.Drawing.Size(345, 129);
+            this.GB_Randomizer.Size = new System.Drawing.Size(345, 133);
             this.GB_Randomizer.TabIndex = 418;
             this.GB_Randomizer.TabStop = false;
             this.GB_Randomizer.Text = "Randomizer Options";
@@ -1198,15 +1229,15 @@
             // L_Same
             // 
             this.L_Same.AutoSize = true;
-            this.L_Same.Location = new System.Drawing.Point(216, 97);
+            this.L_Same.Location = new System.Drawing.Point(213, 99);
             this.L_Same.Name = "L_Same";
-            this.L_Same.Size = new System.Drawing.Size(48, 13);
+            this.L_Same.Size = new System.Drawing.Size(51, 13);
             this.L_Same.TabIndex = 23;
-            this.L_Same.Text = "Same(%)";
+            this.L_Same.Text = "Same (%)";
             // 
             // NUD_Egg
             // 
-            this.NUD_Egg.Location = new System.Drawing.Point(267, 95);
+            this.NUD_Egg.Location = new System.Drawing.Point(267, 97);
             this.NUD_Egg.Name = "NUD_Egg";
             this.NUD_Egg.Size = new System.Drawing.Size(46, 20);
             this.NUD_Egg.TabIndex = 22;
@@ -1314,11 +1345,11 @@
             // L_SingleType
             // 
             this.L_SingleType.AutoSize = true;
-            this.L_SingleType.Location = new System.Drawing.Point(115, 78);
+            this.L_SingleType.Location = new System.Drawing.Point(115, 79);
             this.L_SingleType.Name = "L_SingleType";
-            this.L_SingleType.Size = new System.Drawing.Size(77, 13);
+            this.L_SingleType.Size = new System.Drawing.Size(80, 13);
             this.L_SingleType.TabIndex = 21;
-            this.L_SingleType.Text = "Single Type(%)";
+            this.L_SingleType.Text = "Single Type (%)";
             // 
             // CHK_rDEF
             // 
@@ -1346,7 +1377,7 @@
             // 
             // NUD_TypePercent
             // 
-            this.NUD_TypePercent.Location = new System.Drawing.Point(134, 94);
+            this.NUD_TypePercent.Location = new System.Drawing.Point(134, 95);
             this.NUD_TypePercent.Name = "NUD_TypePercent";
             this.NUD_TypePercent.Size = new System.Drawing.Size(46, 20);
             this.NUD_TypePercent.TabIndex = 20;
@@ -1383,11 +1414,11 @@
             // L_StatDev
             // 
             this.L_StatDev.AutoSize = true;
-            this.L_StatDev.Location = new System.Drawing.Point(6, 90);
+            this.L_StatDev.Location = new System.Drawing.Point(6, 92);
             this.L_StatDev.Name = "L_StatDev";
-            this.L_StatDev.Size = new System.Drawing.Size(67, 13);
+            this.L_StatDev.Size = new System.Drawing.Size(70, 13);
             this.L_StatDev.TabIndex = 4;
-            this.L_StatDev.Text = "Deviance(%)";
+            this.L_StatDev.Text = "Deviance (%)";
             // 
             // CHK_TM
             // 
@@ -1403,7 +1434,7 @@
             // 
             // NUD_StatDev
             // 
-            this.NUD_StatDev.Location = new System.Drawing.Point(27, 106);
+            this.NUD_StatDev.Location = new System.Drawing.Point(27, 108);
             this.NUD_StatDev.Name = "NUD_StatDev";
             this.NUD_StatDev.Size = new System.Drawing.Size(46, 20);
             this.NUD_StatDev.TabIndex = 3;
@@ -1474,7 +1505,7 @@
             // 
             // PB_MonSprite
             // 
-            this.PB_MonSprite.Location = new System.Drawing.Point(285, 0);
+            this.PB_MonSprite.Location = new System.Drawing.Point(285, 1);
             this.PB_MonSprite.Name = "PB_MonSprite";
             this.PB_MonSprite.Size = new System.Drawing.Size(80, 60);
             this.PB_MonSprite.TabIndex = 89;
@@ -1482,7 +1513,7 @@
             // 
             // B_Dump
             // 
-            this.B_Dump.Location = new System.Drawing.Point(368, 10);
+            this.B_Dump.Location = new System.Drawing.Point(368, 19);
             this.B_Dump.Name = "B_Dump";
             this.B_Dump.Size = new System.Drawing.Size(82, 23);
             this.B_Dump.TabIndex = 418;
@@ -1490,29 +1521,19 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
-            // CHK_NoTutor
-            // 
-            this.CHK_NoTutor.AutoSize = true;
-            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
-            this.CHK_NoTutor.Name = "CHK_NoTutor";
-            this.CHK_NoTutor.Size = new System.Drawing.Size(212, 17);
-            this.CHK_NoTutor.TabIndex = 20;
-            this.CHK_NoTutor.Text = "Remove All TM/HM/Tutor Compatibility";
-            this.CHK_NoTutor.UseVisualStyleBackColor = true;
-            // 
             // PersonalEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(469, 416);
+            this.ClientSize = new System.Drawing.Size(469, 426);
             this.Controls.Add(this.B_Dump);
             this.Controls.Add(this.PB_MonSprite);
             this.Controls.Add(this.TC_Pokemon);
             this.Controls.Add(this.L_Species_Precursor);
             this.Controls.Add(this.CB_Species);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(485, 455);
-            this.MinimumSize = new System.Drawing.Size(485, 455);
+            this.MaximumSize = new System.Drawing.Size(485, 465);
+            this.MinimumSize = new System.Drawing.Size(485, 465);
             this.Name = "PersonalEditor6";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Personal Stats Editor";
@@ -1608,7 +1629,6 @@
         private System.Windows.Forms.TextBox TB_Stage;
         private System.Windows.Forms.Label L_Stage;
         private System.Windows.Forms.MaskedTextBox TB_CatchRate;
-        private System.Windows.Forms.TextBox TB_RawColor;
         private System.Windows.Forms.Label L_BST;
 		private System.Windows.Forms.TextBox TB_BST;
         private System.Windows.Forms.CheckedListBox CLB_TMHM;
@@ -1658,5 +1678,8 @@
         private System.Windows.Forms.NumericUpDown NUD_CatchRateMod;
         private System.Windows.Forms.CheckBox CHK_Shuffle;
         private System.Windows.Forms.CheckBox CHK_NoTutor;
+        private System.Windows.Forms.Label L_HiddenAbility;
+        private System.Windows.Forms.Label L_Ability2;
+        private System.Windows.Forms.Label L_Ability1;
     }
 }

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
@@ -148,6 +148,7 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
+            this.TB_RawColor = new System.Windows.Forms.TextBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -197,6 +198,7 @@
             // 
             // TP_General
             // 
+            this.TP_General.Controls.Add(this.TB_RawColor);
             this.TP_General.Controls.Add(this.L_HiddenAbility);
             this.TP_General.Controls.Add(this.L_Ability2);
             this.TP_General.Controls.Add(this.L_Ability1);
@@ -1521,6 +1523,16 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
+            // TB_RawColor
+            // 
+            this.TB_RawColor.Location = new System.Drawing.Point(229, 209);
+            this.TB_RawColor.Name = "TB_RawColor";
+            this.TB_RawColor.ReadOnly = true;
+            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
+            this.TB_RawColor.TabIndex = 419;
+            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.TB_RawColor.Visible = false;
+            // 
             // PersonalEditor6
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1681,5 +1693,6 @@
         private System.Windows.Forms.Label L_HiddenAbility;
         private System.Windows.Forms.Label L_Ability2;
         private System.Windows.Forms.Label L_Ability1;
+        private System.Windows.Forms.TextBox TB_RawColor;
     }
 }

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.cs
@@ -226,8 +226,7 @@ namespace pk3DS
 
             TB_FormeCount.Text = pkm.FormeCount.ToString("000");
             TB_FormeSprite.Text = pkm.FormeSprite.ToString("000");
-
-            TB_RawColor.Text = pkm.Color.ToString("000");
+            
             CB_Color.SelectedIndex = pkm.Color & 0xF;
 
             TB_BaseExp.Text = pkm.BaseEXP.ToString("000");
@@ -306,7 +305,7 @@ namespace pk3DS
 
             pkm.FormeSprite = Convert.ToUInt16(TB_FormeSprite.Text);
             pkm.FormeCount = Convert.ToByte(TB_FormeCount.Text);
-            pkm.Color = (byte) (Convert.ToByte(CB_Color.SelectedIndex) | (Convert.ToByte(TB_RawColor.Text) & 0xF0));
+            pkm.Color = (Convert.ToByte(CB_Color.SelectedIndex));
             pkm.BaseEXP = Convert.ToUInt16(TB_BaseExp.Text);
 
             decimal h; decimal.TryParse(TB_Height.Text, out h);
@@ -337,6 +336,7 @@ namespace pk3DS
 
         private void B_Randomize_Click(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Randomize all? Cannot undo.", "Double check Randomization settings in the Enhancements tab.") != DialogResult.Yes) return;
             saveEntry();
 
             // input settings
@@ -364,10 +364,12 @@ namespace pk3DS
             Main.SpeciesStat.Select(z => z.Write()).ToArray().CopyTo(files, 0);
 
             readEntry();
-            WinFormsUtil.Alert("All relevant Pokémon Personal Entries have been randomized!");
+            WinFormsUtil.Alert("Randomized all Pokémon Personal data entries according to specification!", "Press the Dump All button to view the new Personal data!");
         }
         private void B_ModifyAll(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Modify all? Cannot undo.", "Double check Modification settings in the Enhancements tab.") != DialogResult.Yes) return;
+
             for (int i = 1; i < CB_Species.Items.Count; i++)
             {
                 CB_Species.SelectedIndex = i; // Get new Species
@@ -397,7 +399,7 @@ namespace pk3DS
                     TB_CatchRate.Text = ((int)NUD_CatchRateMod.Value).ToString();
             }
             CB_Species.SelectedIndex = 1;
-            WinFormsUtil.Alert("All species modified according to specification!");
+            WinFormsUtil.Alert("Modified all Pokémon Personal data entries according to specification!", "Press the Dump All button to view the new Personal data!");
         }
         private bool dumping;
         private void B_Dump_Click(object sender, EventArgs e)

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.cs
@@ -226,7 +226,8 @@ namespace pk3DS
 
             TB_FormeCount.Text = pkm.FormeCount.ToString("000");
             TB_FormeSprite.Text = pkm.FormeSprite.ToString("000");
-            
+
+            TB_RawColor.Text = pkm.Color.ToString("000");
             CB_Color.SelectedIndex = pkm.Color & 0xF;
 
             TB_BaseExp.Text = pkm.BaseEXP.ToString("000");
@@ -305,7 +306,7 @@ namespace pk3DS
 
             pkm.FormeSprite = Convert.ToUInt16(TB_FormeSprite.Text);
             pkm.FormeCount = Convert.ToByte(TB_FormeCount.Text);
-            pkm.Color = (Convert.ToByte(CB_Color.SelectedIndex));
+            pkm.Color = (byte)(Convert.ToByte(CB_Color.SelectedIndex) | (Convert.ToByte(TB_RawColor.Text) & 0xF0));
             pkm.BaseEXP = Convert.ToUInt16(TB_BaseExp.Text);
 
             decimal h; decimal.TryParse(TB_Height.Text, out h);

--- a/pk3DS/Subforms/Gen6/RSTE.Designer.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.Designer.cs
@@ -303,7 +303,7 @@
             // checkBox_Healer
             // 
             this.checkBox_Healer.AutoSize = true;
-            this.checkBox_Healer.Location = new System.Drawing.Point(7, 49);
+            this.checkBox_Healer.Location = new System.Drawing.Point(457, 49);
             this.checkBox_Healer.Name = "checkBox_Healer";
             this.checkBox_Healer.Size = new System.Drawing.Size(57, 17);
             this.checkBox_Healer.TabIndex = 58;
@@ -313,7 +313,7 @@
             // L_TPrize
             // 
             this.L_TPrize.AutoSize = true;
-            this.L_TPrize.Location = new System.Drawing.Point(454, 3);
+            this.L_TPrize.Location = new System.Drawing.Point(454, 5);
             this.L_TPrize.Name = "L_TPrize";
             this.L_TPrize.Size = new System.Drawing.Size(33, 13);
             this.L_TPrize.TabIndex = 57;
@@ -332,7 +332,7 @@
             // L_AI
             // 
             this.L_AI.AutoSize = true;
-            this.L_AI.Location = new System.Drawing.Point(11, 103);
+            this.L_AI.Location = new System.Drawing.Point(17, 103);
             this.L_AI.Name = "L_AI";
             this.L_AI.Size = new System.Drawing.Size(49, 13);
             this.L_AI.TabIndex = 55;
@@ -351,7 +351,7 @@
             // L_Money
             // 
             this.L_Money.AutoSize = true;
-            this.L_Money.Location = new System.Drawing.Point(146, 103);
+            this.L_Money.Location = new System.Drawing.Point(152, 103);
             this.L_Money.Name = "L_Money";
             this.L_Money.Size = new System.Drawing.Size(42, 13);
             this.L_Money.TabIndex = 53;
@@ -370,7 +370,7 @@
             // L_Battle_Type
             // 
             this.L_Battle_Type.AutoSize = true;
-            this.L_Battle_Type.Location = new System.Drawing.Point(86, 76);
+            this.L_Battle_Type.Location = new System.Drawing.Point(56, 76);
             this.L_Battle_Type.Name = "L_Battle_Type";
             this.L_Battle_Type.Size = new System.Drawing.Size(64, 13);
             this.L_Battle_Type.TabIndex = 51;
@@ -387,15 +387,15 @@
             "Triple Battle",
             "Rotation Battle",
             "Horde Battle"});
-            this.CB_Battle_Type.Location = new System.Drawing.Point(156, 73);
+            this.CB_Battle_Type.Location = new System.Drawing.Point(121, 73);
             this.CB_Battle_Type.Name = "CB_Battle_Type";
-            this.CB_Battle_Type.Size = new System.Drawing.Size(116, 21);
+            this.CB_Battle_Type.Size = new System.Drawing.Size(151, 21);
             this.CB_Battle_Type.TabIndex = 50;
             // 
             // L_Trainer_Class
             // 
             this.L_Trainer_Class.AutoSize = true;
-            this.L_Trainer_Class.Location = new System.Drawing.Point(79, 49);
+            this.L_Trainer_Class.Location = new System.Drawing.Point(49, 49);
             this.L_Trainer_Class.Name = "L_Trainer_Class";
             this.L_Trainer_Class.Size = new System.Drawing.Size(71, 13);
             this.L_Trainer_Class.TabIndex = 49;
@@ -407,15 +407,15 @@
             this.CB_Trainer_Class.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Trainer_Class.DropDownWidth = 165;
             this.CB_Trainer_Class.FormattingEnabled = true;
-            this.CB_Trainer_Class.Location = new System.Drawing.Point(156, 46);
+            this.CB_Trainer_Class.Location = new System.Drawing.Point(121, 46);
             this.CB_Trainer_Class.Name = "CB_Trainer_Class";
-            this.CB_Trainer_Class.Size = new System.Drawing.Size(116, 21);
+            this.CB_Trainer_Class.Size = new System.Drawing.Size(151, 21);
             this.CB_Trainer_Class.TabIndex = 48;
             // 
             // checkBox_Moves
             // 
             this.checkBox_Moves.AutoSize = true;
-            this.checkBox_Moves.Location = new System.Drawing.Point(7, 65);
+            this.checkBox_Moves.Location = new System.Drawing.Point(457, 76);
             this.checkBox_Moves.Name = "checkBox_Moves";
             this.checkBox_Moves.Size = new System.Drawing.Size(58, 17);
             this.checkBox_Moves.TabIndex = 40;
@@ -426,7 +426,7 @@
             // checkBox_Item
             // 
             this.checkBox_Item.AutoSize = true;
-            this.checkBox_Item.Location = new System.Drawing.Point(7, 81);
+            this.checkBox_Item.Location = new System.Drawing.Point(457, 103);
             this.checkBox_Item.Name = "checkBox_Item";
             this.checkBox_Item.Size = new System.Drawing.Size(51, 17);
             this.checkBox_Item.TabIndex = 39;
@@ -437,7 +437,7 @@
             // L_Item_4
             // 
             this.L_Item_4.AutoSize = true;
-            this.L_Item_4.Location = new System.Drawing.Point(278, 103);
+            this.L_Item_4.Location = new System.Drawing.Point(284, 103);
             this.L_Item_4.Name = "L_Item_4";
             this.L_Item_4.Size = new System.Drawing.Size(39, 13);
             this.L_Item_4.TabIndex = 34;
@@ -448,7 +448,7 @@
             this.CB_Item_4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Item_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Item_4.FormattingEnabled = true;
-            this.CB_Item_4.Location = new System.Drawing.Point(330, 100);
+            this.CB_Item_4.Location = new System.Drawing.Point(324, 100);
             this.CB_Item_4.Name = "CB_Item_4";
             this.CB_Item_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Item_4.TabIndex = 33;
@@ -456,7 +456,7 @@
             // L_Item_3
             // 
             this.L_Item_3.AutoSize = true;
-            this.L_Item_3.Location = new System.Drawing.Point(278, 76);
+            this.L_Item_3.Location = new System.Drawing.Point(284, 76);
             this.L_Item_3.Name = "L_Item_3";
             this.L_Item_3.Size = new System.Drawing.Size(39, 13);
             this.L_Item_3.TabIndex = 32;
@@ -467,7 +467,7 @@
             this.CB_Item_3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Item_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Item_3.FormattingEnabled = true;
-            this.CB_Item_3.Location = new System.Drawing.Point(330, 73);
+            this.CB_Item_3.Location = new System.Drawing.Point(324, 73);
             this.CB_Item_3.Name = "CB_Item_3";
             this.CB_Item_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Item_3.TabIndex = 31;
@@ -475,7 +475,7 @@
             // L_Item_2
             // 
             this.L_Item_2.AutoSize = true;
-            this.L_Item_2.Location = new System.Drawing.Point(278, 49);
+            this.L_Item_2.Location = new System.Drawing.Point(284, 49);
             this.L_Item_2.Name = "L_Item_2";
             this.L_Item_2.Size = new System.Drawing.Size(39, 13);
             this.L_Item_2.TabIndex = 30;
@@ -486,7 +486,7 @@
             this.CB_Item_2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Item_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Item_2.FormattingEnabled = true;
-            this.CB_Item_2.Location = new System.Drawing.Point(330, 46);
+            this.CB_Item_2.Location = new System.Drawing.Point(324, 46);
             this.CB_Item_2.Name = "CB_Item_2";
             this.CB_Item_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Item_2.TabIndex = 29;
@@ -494,7 +494,7 @@
             // L_Item_1
             // 
             this.L_Item_1.AutoSize = true;
-            this.L_Item_1.Location = new System.Drawing.Point(278, 22);
+            this.L_Item_1.Location = new System.Drawing.Point(284, 22);
             this.L_Item_1.Name = "L_Item_1";
             this.L_Item_1.Size = new System.Drawing.Size(39, 13);
             this.L_Item_1.TabIndex = 28;
@@ -505,7 +505,7 @@
             this.CB_Item_1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Item_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Item_1.FormattingEnabled = true;
-            this.CB_Item_1.Location = new System.Drawing.Point(330, 19);
+            this.CB_Item_1.Location = new System.Drawing.Point(324, 19);
             this.CB_Item_1.Name = "CB_Item_1";
             this.CB_Item_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Item_1.TabIndex = 27;
@@ -513,7 +513,7 @@
             // L_numPokemon
             // 
             this.L_numPokemon.AutoSize = true;
-            this.L_numPokemon.Location = new System.Drawing.Point(43, 22);
+            this.L_numPokemon.Location = new System.Drawing.Point(13, 22);
             this.L_numPokemon.Name = "L_numPokemon";
             this.L_numPokemon.Size = new System.Drawing.Size(107, 13);
             this.L_numPokemon.TabIndex = 22;
@@ -532,9 +532,9 @@
             "4",
             "5",
             "6"});
-            this.CB_numPokemon.Location = new System.Drawing.Point(156, 19);
+            this.CB_numPokemon.Location = new System.Drawing.Point(121, 19);
             this.CB_numPokemon.Name = "CB_numPokemon";
-            this.CB_numPokemon.Size = new System.Drawing.Size(116, 21);
+            this.CB_numPokemon.Size = new System.Drawing.Size(151, 21);
             this.CB_numPokemon.TabIndex = 21;
             this.CB_numPokemon.SelectedIndexChanged += new System.EventHandler(this.changeTrainerType);
             // 
@@ -573,7 +573,7 @@
             // L_Pokemon_1_Form
             // 
             this.L_Pokemon_1_Form.AutoSize = true;
-            this.L_Pokemon_1_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_1_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_1_Form.Name = "L_Pokemon_1_Form";
             this.L_Pokemon_1_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_1_Form.TabIndex = 63;
@@ -585,7 +585,7 @@
             this.CB_Pokemon_1_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Ability.Enabled = false;
             this.CB_Pokemon_1_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_1_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_1_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_1_Ability.Name = "CB_Pokemon_1_Ability";
             this.CB_Pokemon_1_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Ability.TabIndex = 62;
@@ -593,7 +593,7 @@
             // L_Pokemon_1_Gender
             // 
             this.L_Pokemon_1_Gender.AutoSize = true;
-            this.L_Pokemon_1_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_1_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_1_Gender.Name = "L_Pokemon_1_Gender";
             this.L_Pokemon_1_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_1_Gender.TabIndex = 59;
@@ -605,7 +605,7 @@
             this.CB_Pokemon_1_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Gender.Enabled = false;
             this.CB_Pokemon_1_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_1_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_1_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_1_Gender.Name = "CB_Pokemon_1_Gender";
             this.CB_Pokemon_1_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Gender.TabIndex = 58;
@@ -614,7 +614,7 @@
             // L_Pokemon_1_Ability
             // 
             this.L_Pokemon_1_Ability.AutoSize = true;
-            this.L_Pokemon_1_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_1_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_1_Ability.Name = "L_Pokemon_1_Ability";
             this.L_Pokemon_1_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_1_Ability.TabIndex = 57;
@@ -626,7 +626,7 @@
             this.CB_Pokemon_1_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Form.Enabled = false;
             this.CB_Pokemon_1_Form.FormattingEnabled = true;
-            this.CB_Pokemon_1_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_1_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_1_Form.Name = "CB_Pokemon_1_Form";
             this.CB_Pokemon_1_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Form.TabIndex = 56;
@@ -635,7 +635,7 @@
             // L_Pokemon_1_IVs
             // 
             this.L_Pokemon_1_IVs.AutoSize = true;
-            this.L_Pokemon_1_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_1_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_1_IVs.Name = "L_Pokemon_1_IVs";
             this.L_Pokemon_1_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_1_IVs.TabIndex = 36;
@@ -647,7 +647,7 @@
             this.CB_Pokemon_1_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_IVs.Enabled = false;
             this.CB_Pokemon_1_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_1_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_1_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_1_IVs.Name = "CB_Pokemon_1_IVs";
             this.CB_Pokemon_1_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_IVs.TabIndex = 35;
@@ -655,7 +655,7 @@
             // L_Pokemon_1_Move_4
             // 
             this.L_Pokemon_1_Move_4.AutoSize = true;
-            this.L_Pokemon_1_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_1_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_1_Move_4.Name = "L_Pokemon_1_Move_4";
             this.L_Pokemon_1_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_1_Move_4.TabIndex = 34;
@@ -667,7 +667,7 @@
             this.CB_Pokemon_1_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Move_4.Enabled = false;
             this.CB_Pokemon_1_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_1_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_1_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_1_Move_4.Name = "CB_Pokemon_1_Move_4";
             this.CB_Pokemon_1_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Move_4.TabIndex = 33;
@@ -675,7 +675,7 @@
             // L_Pokemon_1_Move_3
             // 
             this.L_Pokemon_1_Move_3.AutoSize = true;
-            this.L_Pokemon_1_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_1_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_1_Move_3.Name = "L_Pokemon_1_Move_3";
             this.L_Pokemon_1_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_1_Move_3.TabIndex = 32;
@@ -687,7 +687,7 @@
             this.CB_Pokemon_1_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Move_3.Enabled = false;
             this.CB_Pokemon_1_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_1_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_1_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_1_Move_3.Name = "CB_Pokemon_1_Move_3";
             this.CB_Pokemon_1_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Move_3.TabIndex = 31;
@@ -695,7 +695,7 @@
             // L_Pokemon_1_Move_2
             // 
             this.L_Pokemon_1_Move_2.AutoSize = true;
-            this.L_Pokemon_1_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_1_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_1_Move_2.Name = "L_Pokemon_1_Move_2";
             this.L_Pokemon_1_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_1_Move_2.TabIndex = 30;
@@ -707,7 +707,7 @@
             this.CB_Pokemon_1_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Move_2.Enabled = false;
             this.CB_Pokemon_1_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_1_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_1_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_1_Move_2.Name = "CB_Pokemon_1_Move_2";
             this.CB_Pokemon_1_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Move_2.TabIndex = 29;
@@ -715,7 +715,7 @@
             // L_Pokemon_1_Move_1
             // 
             this.L_Pokemon_1_Move_1.AutoSize = true;
-            this.L_Pokemon_1_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_1_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_1_Move_1.Name = "L_Pokemon_1_Move_1";
             this.L_Pokemon_1_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_1_Move_1.TabIndex = 28;
@@ -727,7 +727,7 @@
             this.CB_Pokemon_1_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Move_1.Enabled = false;
             this.CB_Pokemon_1_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_1_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_1_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_1_Move_1.Name = "CB_Pokemon_1_Move_1";
             this.CB_Pokemon_1_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Move_1.TabIndex = 27;
@@ -735,7 +735,7 @@
             // L_Pokemon_1_Item
             // 
             this.L_Pokemon_1_Item.AutoSize = true;
-            this.L_Pokemon_1_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_Pokemon_1_Item.Location = new System.Drawing.Point(36, 98);
             this.L_Pokemon_1_Item.Name = "L_Pokemon_1_Item";
             this.L_Pokemon_1_Item.Size = new System.Drawing.Size(30, 13);
             this.L_Pokemon_1_Item.TabIndex = 26;
@@ -747,7 +747,7 @@
             this.CB_Pokemon_1_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Item.Enabled = false;
             this.CB_Pokemon_1_Item.FormattingEnabled = true;
-            this.CB_Pokemon_1_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_1_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_1_Item.Name = "CB_Pokemon_1_Item";
             this.CB_Pokemon_1_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Item.TabIndex = 25;
@@ -756,7 +756,7 @@
             // L_Pokemon_1_Level
             // 
             this.L_Pokemon_1_Level.AutoSize = true;
-            this.L_Pokemon_1_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_Pokemon_1_Level.Location = new System.Drawing.Point(30, 71);
             this.L_Pokemon_1_Level.Name = "L_Pokemon_1_Level";
             this.L_Pokemon_1_Level.Size = new System.Drawing.Size(36, 13);
             this.L_Pokemon_1_Level.TabIndex = 24;
@@ -768,7 +768,7 @@
             this.CB_Pokemon_1_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Level.Enabled = false;
             this.CB_Pokemon_1_Level.FormattingEnabled = true;
-            this.CB_Pokemon_1_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_1_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_1_Level.Name = "CB_Pokemon_1_Level";
             this.CB_Pokemon_1_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Level.TabIndex = 23;
@@ -776,7 +776,7 @@
             // L_Pokemon_1_Pokemon
             // 
             this.L_Pokemon_1_Pokemon.AutoSize = true;
-            this.L_Pokemon_1_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_1_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_1_Pokemon.Name = "L_Pokemon_1_Pokemon";
             this.L_Pokemon_1_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_1_Pokemon.TabIndex = 22;
@@ -788,7 +788,7 @@
             this.CB_Pokemon_1_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_1_Pokemon.Enabled = false;
             this.CB_Pokemon_1_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_1_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_1_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_1_Pokemon.Name = "CB_Pokemon_1_Pokemon";
             this.CB_Pokemon_1_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_1_Pokemon.TabIndex = 21;
@@ -829,7 +829,7 @@
             // L_Pokemon_2_Gender
             // 
             this.L_Pokemon_2_Gender.AutoSize = true;
-            this.L_Pokemon_2_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_2_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_2_Gender.Name = "L_Pokemon_2_Gender";
             this.L_Pokemon_2_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_2_Gender.TabIndex = 65;
@@ -841,7 +841,7 @@
             this.CB_Pokemon_2_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Gender.Enabled = false;
             this.CB_Pokemon_2_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_2_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_2_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_2_Gender.Name = "CB_Pokemon_2_Gender";
             this.CB_Pokemon_2_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Gender.TabIndex = 64;
@@ -850,7 +850,7 @@
             // L_Pokemon_2_Ability
             // 
             this.L_Pokemon_2_Ability.AutoSize = true;
-            this.L_Pokemon_2_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_2_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_2_Ability.Name = "L_Pokemon_2_Ability";
             this.L_Pokemon_2_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_2_Ability.TabIndex = 63;
@@ -862,7 +862,7 @@
             this.CB_Pokemon_2_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Ability.Enabled = false;
             this.CB_Pokemon_2_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_2_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_2_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_2_Ability.Name = "CB_Pokemon_2_Ability";
             this.CB_Pokemon_2_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Ability.TabIndex = 62;
@@ -870,7 +870,7 @@
             // L_Pokemon_2_Form
             // 
             this.L_Pokemon_2_Form.AutoSize = true;
-            this.L_Pokemon_2_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_2_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_2_Form.Name = "L_Pokemon_2_Form";
             this.L_Pokemon_2_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_2_Form.TabIndex = 59;
@@ -882,7 +882,7 @@
             this.CB_Pokemon_2_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Form.Enabled = false;
             this.CB_Pokemon_2_Form.FormattingEnabled = true;
-            this.CB_Pokemon_2_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_2_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_2_Form.Name = "CB_Pokemon_2_Form";
             this.CB_Pokemon_2_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Form.TabIndex = 58;
@@ -891,7 +891,7 @@
             // L_Pokemon_2_IVs
             // 
             this.L_Pokemon_2_IVs.AutoSize = true;
-            this.L_Pokemon_2_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_2_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_2_IVs.Name = "L_Pokemon_2_IVs";
             this.L_Pokemon_2_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_2_IVs.TabIndex = 38;
@@ -903,7 +903,7 @@
             this.CB_Pokemon_2_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_IVs.Enabled = false;
             this.CB_Pokemon_2_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_2_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_2_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_2_IVs.Name = "CB_Pokemon_2_IVs";
             this.CB_Pokemon_2_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_IVs.TabIndex = 37;
@@ -911,7 +911,7 @@
             // L_Pokemon_2_Move_4
             // 
             this.L_Pokemon_2_Move_4.AutoSize = true;
-            this.L_Pokemon_2_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_2_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_2_Move_4.Name = "L_Pokemon_2_Move_4";
             this.L_Pokemon_2_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_2_Move_4.TabIndex = 34;
@@ -923,7 +923,7 @@
             this.CB_Pokemon_2_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Move_4.Enabled = false;
             this.CB_Pokemon_2_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_2_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_2_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_2_Move_4.Name = "CB_Pokemon_2_Move_4";
             this.CB_Pokemon_2_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Move_4.TabIndex = 33;
@@ -931,7 +931,7 @@
             // L_Pokemon_2_Move_3
             // 
             this.L_Pokemon_2_Move_3.AutoSize = true;
-            this.L_Pokemon_2_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_2_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_2_Move_3.Name = "L_Pokemon_2_Move_3";
             this.L_Pokemon_2_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_2_Move_3.TabIndex = 32;
@@ -943,7 +943,7 @@
             this.CB_Pokemon_2_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Move_3.Enabled = false;
             this.CB_Pokemon_2_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_2_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_2_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_2_Move_3.Name = "CB_Pokemon_2_Move_3";
             this.CB_Pokemon_2_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Move_3.TabIndex = 31;
@@ -951,7 +951,7 @@
             // L_Pokemon_2_Move_2
             // 
             this.L_Pokemon_2_Move_2.AutoSize = true;
-            this.L_Pokemon_2_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_2_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_2_Move_2.Name = "L_Pokemon_2_Move_2";
             this.L_Pokemon_2_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_2_Move_2.TabIndex = 30;
@@ -963,7 +963,7 @@
             this.CB_Pokemon_2_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Move_2.Enabled = false;
             this.CB_Pokemon_2_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_2_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_2_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_2_Move_2.Name = "CB_Pokemon_2_Move_2";
             this.CB_Pokemon_2_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Move_2.TabIndex = 29;
@@ -971,7 +971,7 @@
             // L_Pokemon_2_Move_1
             // 
             this.L_Pokemon_2_Move_1.AutoSize = true;
-            this.L_Pokemon_2_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_2_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_2_Move_1.Name = "L_Pokemon_2_Move_1";
             this.L_Pokemon_2_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_2_Move_1.TabIndex = 28;
@@ -983,7 +983,7 @@
             this.CB_Pokemon_2_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Move_1.Enabled = false;
             this.CB_Pokemon_2_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_2_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_2_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_2_Move_1.Name = "CB_Pokemon_2_Move_1";
             this.CB_Pokemon_2_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Move_1.TabIndex = 27;
@@ -991,7 +991,7 @@
             // L_Pokemon_2_Item
             // 
             this.L_Pokemon_2_Item.AutoSize = true;
-            this.L_Pokemon_2_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_Pokemon_2_Item.Location = new System.Drawing.Point(36, 98);
             this.L_Pokemon_2_Item.Name = "L_Pokemon_2_Item";
             this.L_Pokemon_2_Item.Size = new System.Drawing.Size(30, 13);
             this.L_Pokemon_2_Item.TabIndex = 26;
@@ -1003,7 +1003,7 @@
             this.CB_Pokemon_2_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Item.Enabled = false;
             this.CB_Pokemon_2_Item.FormattingEnabled = true;
-            this.CB_Pokemon_2_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_2_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_2_Item.Name = "CB_Pokemon_2_Item";
             this.CB_Pokemon_2_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Item.TabIndex = 25;
@@ -1012,7 +1012,7 @@
             // L_CB_Pokemon_2_Level
             // 
             this.L_CB_Pokemon_2_Level.AutoSize = true;
-            this.L_CB_Pokemon_2_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_CB_Pokemon_2_Level.Location = new System.Drawing.Point(30, 71);
             this.L_CB_Pokemon_2_Level.Name = "L_CB_Pokemon_2_Level";
             this.L_CB_Pokemon_2_Level.Size = new System.Drawing.Size(36, 13);
             this.L_CB_Pokemon_2_Level.TabIndex = 24;
@@ -1024,7 +1024,7 @@
             this.CB_Pokemon_2_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Level.Enabled = false;
             this.CB_Pokemon_2_Level.FormattingEnabled = true;
-            this.CB_Pokemon_2_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_2_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_2_Level.Name = "CB_Pokemon_2_Level";
             this.CB_Pokemon_2_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Level.TabIndex = 23;
@@ -1032,7 +1032,7 @@
             // L_Pokemon_2_Pokemon
             // 
             this.L_Pokemon_2_Pokemon.AutoSize = true;
-            this.L_Pokemon_2_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_2_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_2_Pokemon.Name = "L_Pokemon_2_Pokemon";
             this.L_Pokemon_2_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_2_Pokemon.TabIndex = 22;
@@ -1044,7 +1044,7 @@
             this.CB_Pokemon_2_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_2_Pokemon.Enabled = false;
             this.CB_Pokemon_2_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_2_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_2_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_2_Pokemon.Name = "CB_Pokemon_2_Pokemon";
             this.CB_Pokemon_2_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_2_Pokemon.TabIndex = 21;
@@ -1085,7 +1085,7 @@
             // L_Pokemon_3_Gender
             // 
             this.L_Pokemon_3_Gender.AutoSize = true;
-            this.L_Pokemon_3_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_3_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_3_Gender.Name = "L_Pokemon_3_Gender";
             this.L_Pokemon_3_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_3_Gender.TabIndex = 65;
@@ -1097,7 +1097,7 @@
             this.CB_Pokemon_3_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Gender.Enabled = false;
             this.CB_Pokemon_3_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_3_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_3_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_3_Gender.Name = "CB_Pokemon_3_Gender";
             this.CB_Pokemon_3_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Gender.TabIndex = 64;
@@ -1106,7 +1106,7 @@
             // L_Pokemon_3_Ability
             // 
             this.L_Pokemon_3_Ability.AutoSize = true;
-            this.L_Pokemon_3_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_3_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_3_Ability.Name = "L_Pokemon_3_Ability";
             this.L_Pokemon_3_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_3_Ability.TabIndex = 63;
@@ -1118,7 +1118,7 @@
             this.CB_Pokemon_3_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Ability.Enabled = false;
             this.CB_Pokemon_3_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_3_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_3_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_3_Ability.Name = "CB_Pokemon_3_Ability";
             this.CB_Pokemon_3_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Ability.TabIndex = 62;
@@ -1126,7 +1126,7 @@
             // L_Pokemon_3_Form
             // 
             this.L_Pokemon_3_Form.AutoSize = true;
-            this.L_Pokemon_3_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_3_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_3_Form.Name = "L_Pokemon_3_Form";
             this.L_Pokemon_3_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_3_Form.TabIndex = 59;
@@ -1138,7 +1138,7 @@
             this.CB_Pokemon_3_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Form.Enabled = false;
             this.CB_Pokemon_3_Form.FormattingEnabled = true;
-            this.CB_Pokemon_3_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_3_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_3_Form.Name = "CB_Pokemon_3_Form";
             this.CB_Pokemon_3_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Form.TabIndex = 58;
@@ -1147,7 +1147,7 @@
             // L_Pokemon_3_IVs
             // 
             this.L_Pokemon_3_IVs.AutoSize = true;
-            this.L_Pokemon_3_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_3_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_3_IVs.Name = "L_Pokemon_3_IVs";
             this.L_Pokemon_3_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_3_IVs.TabIndex = 38;
@@ -1159,7 +1159,7 @@
             this.CB_Pokemon_3_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_IVs.Enabled = false;
             this.CB_Pokemon_3_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_3_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_3_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_3_IVs.Name = "CB_Pokemon_3_IVs";
             this.CB_Pokemon_3_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_IVs.TabIndex = 37;
@@ -1167,7 +1167,7 @@
             // L_Pokemon_3_Move_4
             // 
             this.L_Pokemon_3_Move_4.AutoSize = true;
-            this.L_Pokemon_3_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_3_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_3_Move_4.Name = "L_Pokemon_3_Move_4";
             this.L_Pokemon_3_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_3_Move_4.TabIndex = 34;
@@ -1179,7 +1179,7 @@
             this.CB_Pokemon_3_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Move_4.Enabled = false;
             this.CB_Pokemon_3_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_3_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_3_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_3_Move_4.Name = "CB_Pokemon_3_Move_4";
             this.CB_Pokemon_3_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Move_4.TabIndex = 33;
@@ -1187,7 +1187,7 @@
             // L_Pokemon_3_Move_3
             // 
             this.L_Pokemon_3_Move_3.AutoSize = true;
-            this.L_Pokemon_3_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_3_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_3_Move_3.Name = "L_Pokemon_3_Move_3";
             this.L_Pokemon_3_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_3_Move_3.TabIndex = 32;
@@ -1199,7 +1199,7 @@
             this.CB_Pokemon_3_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Move_3.Enabled = false;
             this.CB_Pokemon_3_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_3_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_3_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_3_Move_3.Name = "CB_Pokemon_3_Move_3";
             this.CB_Pokemon_3_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Move_3.TabIndex = 31;
@@ -1207,7 +1207,7 @@
             // L_Pokemon_3_Move_2
             // 
             this.L_Pokemon_3_Move_2.AutoSize = true;
-            this.L_Pokemon_3_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_3_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_3_Move_2.Name = "L_Pokemon_3_Move_2";
             this.L_Pokemon_3_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_3_Move_2.TabIndex = 30;
@@ -1219,7 +1219,7 @@
             this.CB_Pokemon_3_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Move_2.Enabled = false;
             this.CB_Pokemon_3_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_3_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_3_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_3_Move_2.Name = "CB_Pokemon_3_Move_2";
             this.CB_Pokemon_3_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Move_2.TabIndex = 29;
@@ -1227,7 +1227,7 @@
             // L_Pokemon_3_Move_1
             // 
             this.L_Pokemon_3_Move_1.AutoSize = true;
-            this.L_Pokemon_3_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_3_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_3_Move_1.Name = "L_Pokemon_3_Move_1";
             this.L_Pokemon_3_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_3_Move_1.TabIndex = 28;
@@ -1239,7 +1239,7 @@
             this.CB_Pokemon_3_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Move_1.Enabled = false;
             this.CB_Pokemon_3_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_3_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_3_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_3_Move_1.Name = "CB_Pokemon_3_Move_1";
             this.CB_Pokemon_3_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Move_1.TabIndex = 27;
@@ -1247,7 +1247,7 @@
             // L_Pokemon_3_Item
             // 
             this.L_Pokemon_3_Item.AutoSize = true;
-            this.L_Pokemon_3_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_Pokemon_3_Item.Location = new System.Drawing.Point(36, 98);
             this.L_Pokemon_3_Item.Name = "L_Pokemon_3_Item";
             this.L_Pokemon_3_Item.Size = new System.Drawing.Size(30, 13);
             this.L_Pokemon_3_Item.TabIndex = 26;
@@ -1259,7 +1259,7 @@
             this.CB_Pokemon_3_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Item.Enabled = false;
             this.CB_Pokemon_3_Item.FormattingEnabled = true;
-            this.CB_Pokemon_3_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_3_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_3_Item.Name = "CB_Pokemon_3_Item";
             this.CB_Pokemon_3_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Item.TabIndex = 25;
@@ -1268,7 +1268,7 @@
             // L_Pokemon_3_Level
             // 
             this.L_Pokemon_3_Level.AutoSize = true;
-            this.L_Pokemon_3_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_Pokemon_3_Level.Location = new System.Drawing.Point(30, 71);
             this.L_Pokemon_3_Level.Name = "L_Pokemon_3_Level";
             this.L_Pokemon_3_Level.Size = new System.Drawing.Size(36, 13);
             this.L_Pokemon_3_Level.TabIndex = 24;
@@ -1280,7 +1280,7 @@
             this.CB_Pokemon_3_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Level.Enabled = false;
             this.CB_Pokemon_3_Level.FormattingEnabled = true;
-            this.CB_Pokemon_3_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_3_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_3_Level.Name = "CB_Pokemon_3_Level";
             this.CB_Pokemon_3_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Level.TabIndex = 23;
@@ -1288,7 +1288,7 @@
             // L_Pokemon_3_Pokemon
             // 
             this.L_Pokemon_3_Pokemon.AutoSize = true;
-            this.L_Pokemon_3_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_3_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_3_Pokemon.Name = "L_Pokemon_3_Pokemon";
             this.L_Pokemon_3_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_3_Pokemon.TabIndex = 22;
@@ -1300,7 +1300,7 @@
             this.CB_Pokemon_3_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_3_Pokemon.Enabled = false;
             this.CB_Pokemon_3_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_3_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_3_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_3_Pokemon.Name = "CB_Pokemon_3_Pokemon";
             this.CB_Pokemon_3_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_3_Pokemon.TabIndex = 21;
@@ -1341,7 +1341,7 @@
             // L_Pokemon_4_Gender
             // 
             this.L_Pokemon_4_Gender.AutoSize = true;
-            this.L_Pokemon_4_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_4_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_4_Gender.Name = "L_Pokemon_4_Gender";
             this.L_Pokemon_4_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_4_Gender.TabIndex = 65;
@@ -1353,7 +1353,7 @@
             this.CB_Pokemon_4_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Gender.Enabled = false;
             this.CB_Pokemon_4_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_4_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_4_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_4_Gender.Name = "CB_Pokemon_4_Gender";
             this.CB_Pokemon_4_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Gender.TabIndex = 64;
@@ -1362,7 +1362,7 @@
             // L_Pokemon_4_Ability
             // 
             this.L_Pokemon_4_Ability.AutoSize = true;
-            this.L_Pokemon_4_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_4_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_4_Ability.Name = "L_Pokemon_4_Ability";
             this.L_Pokemon_4_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_4_Ability.TabIndex = 63;
@@ -1374,7 +1374,7 @@
             this.CB_Pokemon_4_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Ability.Enabled = false;
             this.CB_Pokemon_4_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_4_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_4_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_4_Ability.Name = "CB_Pokemon_4_Ability";
             this.CB_Pokemon_4_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Ability.TabIndex = 62;
@@ -1382,7 +1382,7 @@
             // L_Pokemon_4_Form
             // 
             this.L_Pokemon_4_Form.AutoSize = true;
-            this.L_Pokemon_4_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_4_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_4_Form.Name = "L_Pokemon_4_Form";
             this.L_Pokemon_4_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_4_Form.TabIndex = 59;
@@ -1394,7 +1394,7 @@
             this.CB_Pokemon_4_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Form.Enabled = false;
             this.CB_Pokemon_4_Form.FormattingEnabled = true;
-            this.CB_Pokemon_4_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_4_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_4_Form.Name = "CB_Pokemon_4_Form";
             this.CB_Pokemon_4_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Form.TabIndex = 58;
@@ -1403,7 +1403,7 @@
             // L_Pokemon_4_IVs
             // 
             this.L_Pokemon_4_IVs.AutoSize = true;
-            this.L_Pokemon_4_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_4_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_4_IVs.Name = "L_Pokemon_4_IVs";
             this.L_Pokemon_4_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_4_IVs.TabIndex = 38;
@@ -1415,7 +1415,7 @@
             this.CB_Pokemon_4_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_IVs.Enabled = false;
             this.CB_Pokemon_4_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_4_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_4_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_4_IVs.Name = "CB_Pokemon_4_IVs";
             this.CB_Pokemon_4_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_IVs.TabIndex = 37;
@@ -1423,7 +1423,7 @@
             // L_Pokemon_4_Move_4
             // 
             this.L_Pokemon_4_Move_4.AutoSize = true;
-            this.L_Pokemon_4_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_4_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_4_Move_4.Name = "L_Pokemon_4_Move_4";
             this.L_Pokemon_4_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_4_Move_4.TabIndex = 34;
@@ -1435,7 +1435,7 @@
             this.CB_Pokemon_4_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Move_4.Enabled = false;
             this.CB_Pokemon_4_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_4_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_4_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_4_Move_4.Name = "CB_Pokemon_4_Move_4";
             this.CB_Pokemon_4_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Move_4.TabIndex = 33;
@@ -1443,7 +1443,7 @@
             // L_Pokemon_4_Move_3
             // 
             this.L_Pokemon_4_Move_3.AutoSize = true;
-            this.L_Pokemon_4_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_4_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_4_Move_3.Name = "L_Pokemon_4_Move_3";
             this.L_Pokemon_4_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_4_Move_3.TabIndex = 32;
@@ -1455,7 +1455,7 @@
             this.CB_Pokemon_4_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Move_3.Enabled = false;
             this.CB_Pokemon_4_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_4_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_4_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_4_Move_3.Name = "CB_Pokemon_4_Move_3";
             this.CB_Pokemon_4_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Move_3.TabIndex = 31;
@@ -1463,7 +1463,7 @@
             // L_Pokemon_4_Move_2
             // 
             this.L_Pokemon_4_Move_2.AutoSize = true;
-            this.L_Pokemon_4_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_4_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_4_Move_2.Name = "L_Pokemon_4_Move_2";
             this.L_Pokemon_4_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_4_Move_2.TabIndex = 30;
@@ -1475,7 +1475,7 @@
             this.CB_Pokemon_4_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Move_2.Enabled = false;
             this.CB_Pokemon_4_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_4_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_4_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_4_Move_2.Name = "CB_Pokemon_4_Move_2";
             this.CB_Pokemon_4_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Move_2.TabIndex = 29;
@@ -1483,7 +1483,7 @@
             // L_Pokemon_4_Move_1
             // 
             this.L_Pokemon_4_Move_1.AutoSize = true;
-            this.L_Pokemon_4_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_4_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_4_Move_1.Name = "L_Pokemon_4_Move_1";
             this.L_Pokemon_4_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_4_Move_1.TabIndex = 28;
@@ -1495,7 +1495,7 @@
             this.CB_Pokemon_4_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Move_1.Enabled = false;
             this.CB_Pokemon_4_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_4_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_4_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_4_Move_1.Name = "CB_Pokemon_4_Move_1";
             this.CB_Pokemon_4_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Move_1.TabIndex = 27;
@@ -1503,7 +1503,7 @@
             // L_CB_Pokemon_4_Item
             // 
             this.L_CB_Pokemon_4_Item.AutoSize = true;
-            this.L_CB_Pokemon_4_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_CB_Pokemon_4_Item.Location = new System.Drawing.Point(36, 98);
             this.L_CB_Pokemon_4_Item.Name = "L_CB_Pokemon_4_Item";
             this.L_CB_Pokemon_4_Item.Size = new System.Drawing.Size(30, 13);
             this.L_CB_Pokemon_4_Item.TabIndex = 26;
@@ -1515,7 +1515,7 @@
             this.CB_Pokemon_4_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Item.Enabled = false;
             this.CB_Pokemon_4_Item.FormattingEnabled = true;
-            this.CB_Pokemon_4_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_4_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_4_Item.Name = "CB_Pokemon_4_Item";
             this.CB_Pokemon_4_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Item.TabIndex = 25;
@@ -1524,7 +1524,7 @@
             // L_Pokemon_4_Level
             // 
             this.L_Pokemon_4_Level.AutoSize = true;
-            this.L_Pokemon_4_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_Pokemon_4_Level.Location = new System.Drawing.Point(30, 71);
             this.L_Pokemon_4_Level.Name = "L_Pokemon_4_Level";
             this.L_Pokemon_4_Level.Size = new System.Drawing.Size(36, 13);
             this.L_Pokemon_4_Level.TabIndex = 24;
@@ -1536,7 +1536,7 @@
             this.CB_Pokemon_4_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Level.Enabled = false;
             this.CB_Pokemon_4_Level.FormattingEnabled = true;
-            this.CB_Pokemon_4_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_4_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_4_Level.Name = "CB_Pokemon_4_Level";
             this.CB_Pokemon_4_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Level.TabIndex = 23;
@@ -1544,7 +1544,7 @@
             // L_Pokemon_4_Pokemon
             // 
             this.L_Pokemon_4_Pokemon.AutoSize = true;
-            this.L_Pokemon_4_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_4_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_4_Pokemon.Name = "L_Pokemon_4_Pokemon";
             this.L_Pokemon_4_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_4_Pokemon.TabIndex = 22;
@@ -1556,7 +1556,7 @@
             this.CB_Pokemon_4_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_4_Pokemon.Enabled = false;
             this.CB_Pokemon_4_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_4_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_4_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_4_Pokemon.Name = "CB_Pokemon_4_Pokemon";
             this.CB_Pokemon_4_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_4_Pokemon.TabIndex = 21;
@@ -1597,7 +1597,7 @@
             // L_Pokemon_5_Gender
             // 
             this.L_Pokemon_5_Gender.AutoSize = true;
-            this.L_Pokemon_5_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_5_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_5_Gender.Name = "L_Pokemon_5_Gender";
             this.L_Pokemon_5_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_5_Gender.TabIndex = 65;
@@ -1609,7 +1609,7 @@
             this.CB_Pokemon_5_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Gender.Enabled = false;
             this.CB_Pokemon_5_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_5_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_5_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_5_Gender.Name = "CB_Pokemon_5_Gender";
             this.CB_Pokemon_5_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Gender.TabIndex = 64;
@@ -1618,7 +1618,7 @@
             // L_Pokemon_5_Ability
             // 
             this.L_Pokemon_5_Ability.AutoSize = true;
-            this.L_Pokemon_5_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_5_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_5_Ability.Name = "L_Pokemon_5_Ability";
             this.L_Pokemon_5_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_5_Ability.TabIndex = 63;
@@ -1630,7 +1630,7 @@
             this.CB_Pokemon_5_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Ability.Enabled = false;
             this.CB_Pokemon_5_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_5_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_5_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_5_Ability.Name = "CB_Pokemon_5_Ability";
             this.CB_Pokemon_5_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Ability.TabIndex = 62;
@@ -1638,7 +1638,7 @@
             // L_Pokemon_5_Form
             // 
             this.L_Pokemon_5_Form.AutoSize = true;
-            this.L_Pokemon_5_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_5_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_5_Form.Name = "L_Pokemon_5_Form";
             this.L_Pokemon_5_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_5_Form.TabIndex = 59;
@@ -1650,7 +1650,7 @@
             this.CB_Pokemon_5_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Form.Enabled = false;
             this.CB_Pokemon_5_Form.FormattingEnabled = true;
-            this.CB_Pokemon_5_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_5_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_5_Form.Name = "CB_Pokemon_5_Form";
             this.CB_Pokemon_5_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Form.TabIndex = 58;
@@ -1659,7 +1659,7 @@
             // L_Pokemon_5_IVs
             // 
             this.L_Pokemon_5_IVs.AutoSize = true;
-            this.L_Pokemon_5_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_5_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_5_IVs.Name = "L_Pokemon_5_IVs";
             this.L_Pokemon_5_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_5_IVs.TabIndex = 38;
@@ -1671,7 +1671,7 @@
             this.CB_Pokemon_5_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_IVs.Enabled = false;
             this.CB_Pokemon_5_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_5_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_5_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_5_IVs.Name = "CB_Pokemon_5_IVs";
             this.CB_Pokemon_5_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_IVs.TabIndex = 37;
@@ -1679,7 +1679,7 @@
             // L_Pokemon_5_Move_4
             // 
             this.L_Pokemon_5_Move_4.AutoSize = true;
-            this.L_Pokemon_5_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_5_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_5_Move_4.Name = "L_Pokemon_5_Move_4";
             this.L_Pokemon_5_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_5_Move_4.TabIndex = 34;
@@ -1691,7 +1691,7 @@
             this.CB_Pokemon_5_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Move_4.Enabled = false;
             this.CB_Pokemon_5_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_5_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_5_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_5_Move_4.Name = "CB_Pokemon_5_Move_4";
             this.CB_Pokemon_5_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Move_4.TabIndex = 33;
@@ -1699,7 +1699,7 @@
             // L_Pokemon_5_Move_3
             // 
             this.L_Pokemon_5_Move_3.AutoSize = true;
-            this.L_Pokemon_5_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_5_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_5_Move_3.Name = "L_Pokemon_5_Move_3";
             this.L_Pokemon_5_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_5_Move_3.TabIndex = 32;
@@ -1711,7 +1711,7 @@
             this.CB_Pokemon_5_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Move_3.Enabled = false;
             this.CB_Pokemon_5_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_5_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_5_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_5_Move_3.Name = "CB_Pokemon_5_Move_3";
             this.CB_Pokemon_5_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Move_3.TabIndex = 31;
@@ -1719,7 +1719,7 @@
             // L_Pokemon_5_Move_2
             // 
             this.L_Pokemon_5_Move_2.AutoSize = true;
-            this.L_Pokemon_5_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_5_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_5_Move_2.Name = "L_Pokemon_5_Move_2";
             this.L_Pokemon_5_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_5_Move_2.TabIndex = 30;
@@ -1731,7 +1731,7 @@
             this.CB_Pokemon_5_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Move_2.Enabled = false;
             this.CB_Pokemon_5_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_5_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_5_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_5_Move_2.Name = "CB_Pokemon_5_Move_2";
             this.CB_Pokemon_5_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Move_2.TabIndex = 29;
@@ -1739,7 +1739,7 @@
             // L_Pokemon_5_Move_1
             // 
             this.L_Pokemon_5_Move_1.AutoSize = true;
-            this.L_Pokemon_5_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_5_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_5_Move_1.Name = "L_Pokemon_5_Move_1";
             this.L_Pokemon_5_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_5_Move_1.TabIndex = 28;
@@ -1751,7 +1751,7 @@
             this.CB_Pokemon_5_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Move_1.Enabled = false;
             this.CB_Pokemon_5_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_5_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_5_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_5_Move_1.Name = "CB_Pokemon_5_Move_1";
             this.CB_Pokemon_5_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Move_1.TabIndex = 27;
@@ -1759,7 +1759,7 @@
             // L_Pokemon_5_Item
             // 
             this.L_Pokemon_5_Item.AutoSize = true;
-            this.L_Pokemon_5_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_Pokemon_5_Item.Location = new System.Drawing.Point(36, 98);
             this.L_Pokemon_5_Item.Name = "L_Pokemon_5_Item";
             this.L_Pokemon_5_Item.Size = new System.Drawing.Size(30, 13);
             this.L_Pokemon_5_Item.TabIndex = 26;
@@ -1771,7 +1771,7 @@
             this.CB_Pokemon_5_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Item.Enabled = false;
             this.CB_Pokemon_5_Item.FormattingEnabled = true;
-            this.CB_Pokemon_5_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_5_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_5_Item.Name = "CB_Pokemon_5_Item";
             this.CB_Pokemon_5_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Item.TabIndex = 25;
@@ -1780,7 +1780,7 @@
             // L_Pokemon_5_Level
             // 
             this.L_Pokemon_5_Level.AutoSize = true;
-            this.L_Pokemon_5_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_Pokemon_5_Level.Location = new System.Drawing.Point(30, 71);
             this.L_Pokemon_5_Level.Name = "L_Pokemon_5_Level";
             this.L_Pokemon_5_Level.Size = new System.Drawing.Size(36, 13);
             this.L_Pokemon_5_Level.TabIndex = 24;
@@ -1792,7 +1792,7 @@
             this.CB_Pokemon_5_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Level.Enabled = false;
             this.CB_Pokemon_5_Level.FormattingEnabled = true;
-            this.CB_Pokemon_5_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_5_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_5_Level.Name = "CB_Pokemon_5_Level";
             this.CB_Pokemon_5_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Level.TabIndex = 23;
@@ -1800,7 +1800,7 @@
             // L_Pokemon_5_Pokemon
             // 
             this.L_Pokemon_5_Pokemon.AutoSize = true;
-            this.L_Pokemon_5_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_5_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_5_Pokemon.Name = "L_Pokemon_5_Pokemon";
             this.L_Pokemon_5_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_5_Pokemon.TabIndex = 22;
@@ -1812,7 +1812,7 @@
             this.CB_Pokemon_5_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_5_Pokemon.Enabled = false;
             this.CB_Pokemon_5_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_5_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_5_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_5_Pokemon.Name = "CB_Pokemon_5_Pokemon";
             this.CB_Pokemon_5_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_5_Pokemon.TabIndex = 21;
@@ -1853,7 +1853,7 @@
             // L_Pokemon_6_Gender
             // 
             this.L_Pokemon_6_Gender.AutoSize = true;
-            this.L_Pokemon_6_Gender.Location = new System.Drawing.Point(378, 63);
+            this.L_Pokemon_6_Gender.Location = new System.Drawing.Point(378, 71);
             this.L_Pokemon_6_Gender.Name = "L_Pokemon_6_Gender";
             this.L_Pokemon_6_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Pokemon_6_Gender.TabIndex = 65;
@@ -1865,7 +1865,7 @@
             this.CB_Pokemon_6_Gender.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Gender.Enabled = false;
             this.CB_Pokemon_6_Gender.FormattingEnabled = true;
-            this.CB_Pokemon_6_Gender.Location = new System.Drawing.Point(429, 60);
+            this.CB_Pokemon_6_Gender.Location = new System.Drawing.Point(429, 68);
             this.CB_Pokemon_6_Gender.Name = "CB_Pokemon_6_Gender";
             this.CB_Pokemon_6_Gender.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Gender.TabIndex = 64;
@@ -1874,7 +1874,7 @@
             // L_Pokemon_6_Ability
             // 
             this.L_Pokemon_6_Ability.AutoSize = true;
-            this.L_Pokemon_6_Ability.Location = new System.Drawing.Point(386, 36);
+            this.L_Pokemon_6_Ability.Location = new System.Drawing.Point(386, 44);
             this.L_Pokemon_6_Ability.Name = "L_Pokemon_6_Ability";
             this.L_Pokemon_6_Ability.Size = new System.Drawing.Size(37, 13);
             this.L_Pokemon_6_Ability.TabIndex = 63;
@@ -1886,7 +1886,7 @@
             this.CB_Pokemon_6_Ability.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Ability.Enabled = false;
             this.CB_Pokemon_6_Ability.FormattingEnabled = true;
-            this.CB_Pokemon_6_Ability.Location = new System.Drawing.Point(429, 33);
+            this.CB_Pokemon_6_Ability.Location = new System.Drawing.Point(429, 41);
             this.CB_Pokemon_6_Ability.Name = "CB_Pokemon_6_Ability";
             this.CB_Pokemon_6_Ability.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Ability.TabIndex = 62;
@@ -1894,7 +1894,7 @@
             // L_Pokemon_6_Form
             // 
             this.L_Pokemon_6_Form.AutoSize = true;
-            this.L_Pokemon_6_Form.Location = new System.Drawing.Point(33, 36);
+            this.L_Pokemon_6_Form.Location = new System.Drawing.Point(33, 44);
             this.L_Pokemon_6_Form.Name = "L_Pokemon_6_Form";
             this.L_Pokemon_6_Form.Size = new System.Drawing.Size(33, 13);
             this.L_Pokemon_6_Form.TabIndex = 59;
@@ -1906,7 +1906,7 @@
             this.CB_Pokemon_6_Form.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Form.Enabled = false;
             this.CB_Pokemon_6_Form.FormattingEnabled = true;
-            this.CB_Pokemon_6_Form.Location = new System.Drawing.Point(72, 33);
+            this.CB_Pokemon_6_Form.Location = new System.Drawing.Point(72, 41);
             this.CB_Pokemon_6_Form.Name = "CB_Pokemon_6_Form";
             this.CB_Pokemon_6_Form.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Form.TabIndex = 58;
@@ -1915,7 +1915,7 @@
             // L_Pokemon_6_IVs
             // 
             this.L_Pokemon_6_IVs.AutoSize = true;
-            this.L_Pokemon_6_IVs.Location = new System.Drawing.Point(398, 9);
+            this.L_Pokemon_6_IVs.Location = new System.Drawing.Point(398, 17);
             this.L_Pokemon_6_IVs.Name = "L_Pokemon_6_IVs";
             this.L_Pokemon_6_IVs.Size = new System.Drawing.Size(25, 13);
             this.L_Pokemon_6_IVs.TabIndex = 38;
@@ -1927,7 +1927,7 @@
             this.CB_Pokemon_6_IVs.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_IVs.Enabled = false;
             this.CB_Pokemon_6_IVs.FormattingEnabled = true;
-            this.CB_Pokemon_6_IVs.Location = new System.Drawing.Point(429, 6);
+            this.CB_Pokemon_6_IVs.Location = new System.Drawing.Point(429, 14);
             this.CB_Pokemon_6_IVs.Name = "CB_Pokemon_6_IVs";
             this.CB_Pokemon_6_IVs.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_IVs.TabIndex = 37;
@@ -1935,7 +1935,7 @@
             // L_Pokemon_6_Move_4
             // 
             this.L_Pokemon_6_Move_4.AutoSize = true;
-            this.L_Pokemon_6_Move_4.Location = new System.Drawing.Point(199, 90);
+            this.L_Pokemon_6_Move_4.Location = new System.Drawing.Point(199, 98);
             this.L_Pokemon_6_Move_4.Name = "L_Pokemon_6_Move_4";
             this.L_Pokemon_6_Move_4.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_6_Move_4.TabIndex = 34;
@@ -1947,7 +1947,7 @@
             this.CB_Pokemon_6_Move_4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Move_4.Enabled = false;
             this.CB_Pokemon_6_Move_4.FormattingEnabled = true;
-            this.CB_Pokemon_6_Move_4.Location = new System.Drawing.Point(251, 87);
+            this.CB_Pokemon_6_Move_4.Location = new System.Drawing.Point(251, 95);
             this.CB_Pokemon_6_Move_4.Name = "CB_Pokemon_6_Move_4";
             this.CB_Pokemon_6_Move_4.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Move_4.TabIndex = 33;
@@ -1955,7 +1955,7 @@
             // L_Pokemon_6_Move_3
             // 
             this.L_Pokemon_6_Move_3.AutoSize = true;
-            this.L_Pokemon_6_Move_3.Location = new System.Drawing.Point(199, 63);
+            this.L_Pokemon_6_Move_3.Location = new System.Drawing.Point(199, 71);
             this.L_Pokemon_6_Move_3.Name = "L_Pokemon_6_Move_3";
             this.L_Pokemon_6_Move_3.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_6_Move_3.TabIndex = 32;
@@ -1967,7 +1967,7 @@
             this.CB_Pokemon_6_Move_3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Move_3.Enabled = false;
             this.CB_Pokemon_6_Move_3.FormattingEnabled = true;
-            this.CB_Pokemon_6_Move_3.Location = new System.Drawing.Point(251, 60);
+            this.CB_Pokemon_6_Move_3.Location = new System.Drawing.Point(251, 68);
             this.CB_Pokemon_6_Move_3.Name = "CB_Pokemon_6_Move_3";
             this.CB_Pokemon_6_Move_3.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Move_3.TabIndex = 31;
@@ -1975,7 +1975,7 @@
             // L_Pokemon_6_Move_2
             // 
             this.L_Pokemon_6_Move_2.AutoSize = true;
-            this.L_Pokemon_6_Move_2.Location = new System.Drawing.Point(199, 36);
+            this.L_Pokemon_6_Move_2.Location = new System.Drawing.Point(199, 44);
             this.L_Pokemon_6_Move_2.Name = "L_Pokemon_6_Move_2";
             this.L_Pokemon_6_Move_2.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_6_Move_2.TabIndex = 30;
@@ -1987,7 +1987,7 @@
             this.CB_Pokemon_6_Move_2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Move_2.Enabled = false;
             this.CB_Pokemon_6_Move_2.FormattingEnabled = true;
-            this.CB_Pokemon_6_Move_2.Location = new System.Drawing.Point(251, 33);
+            this.CB_Pokemon_6_Move_2.Location = new System.Drawing.Point(251, 41);
             this.CB_Pokemon_6_Move_2.Name = "CB_Pokemon_6_Move_2";
             this.CB_Pokemon_6_Move_2.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Move_2.TabIndex = 29;
@@ -1995,7 +1995,7 @@
             // L_Pokemon_6_Move_1
             // 
             this.L_Pokemon_6_Move_1.AutoSize = true;
-            this.L_Pokemon_6_Move_1.Location = new System.Drawing.Point(199, 9);
+            this.L_Pokemon_6_Move_1.Location = new System.Drawing.Point(199, 17);
             this.L_Pokemon_6_Move_1.Name = "L_Pokemon_6_Move_1";
             this.L_Pokemon_6_Move_1.Size = new System.Drawing.Size(46, 13);
             this.L_Pokemon_6_Move_1.TabIndex = 28;
@@ -2007,7 +2007,7 @@
             this.CB_Pokemon_6_Move_1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Move_1.Enabled = false;
             this.CB_Pokemon_6_Move_1.FormattingEnabled = true;
-            this.CB_Pokemon_6_Move_1.Location = new System.Drawing.Point(251, 6);
+            this.CB_Pokemon_6_Move_1.Location = new System.Drawing.Point(251, 14);
             this.CB_Pokemon_6_Move_1.Name = "CB_Pokemon_6_Move_1";
             this.CB_Pokemon_6_Move_1.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Move_1.TabIndex = 27;
@@ -2015,7 +2015,7 @@
             // L_Pokemon_6_Item
             // 
             this.L_Pokemon_6_Item.AutoSize = true;
-            this.L_Pokemon_6_Item.Location = new System.Drawing.Point(36, 90);
+            this.L_Pokemon_6_Item.Location = new System.Drawing.Point(36, 98);
             this.L_Pokemon_6_Item.Name = "L_Pokemon_6_Item";
             this.L_Pokemon_6_Item.Size = new System.Drawing.Size(30, 13);
             this.L_Pokemon_6_Item.TabIndex = 26;
@@ -2027,7 +2027,7 @@
             this.CB_Pokemon_6_Item.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Item.Enabled = false;
             this.CB_Pokemon_6_Item.FormattingEnabled = true;
-            this.CB_Pokemon_6_Item.Location = new System.Drawing.Point(72, 87);
+            this.CB_Pokemon_6_Item.Location = new System.Drawing.Point(72, 95);
             this.CB_Pokemon_6_Item.Name = "CB_Pokemon_6_Item";
             this.CB_Pokemon_6_Item.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Item.TabIndex = 25;
@@ -2036,7 +2036,7 @@
             // L_Pokemon_6_Level
             // 
             this.L_Pokemon_6_Level.AutoSize = true;
-            this.L_Pokemon_6_Level.Location = new System.Drawing.Point(30, 63);
+            this.L_Pokemon_6_Level.Location = new System.Drawing.Point(30, 71);
             this.L_Pokemon_6_Level.Name = "L_Pokemon_6_Level";
             this.L_Pokemon_6_Level.Size = new System.Drawing.Size(36, 13);
             this.L_Pokemon_6_Level.TabIndex = 24;
@@ -2048,7 +2048,7 @@
             this.CB_Pokemon_6_Level.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Level.Enabled = false;
             this.CB_Pokemon_6_Level.FormattingEnabled = true;
-            this.CB_Pokemon_6_Level.Location = new System.Drawing.Point(72, 60);
+            this.CB_Pokemon_6_Level.Location = new System.Drawing.Point(72, 68);
             this.CB_Pokemon_6_Level.Name = "CB_Pokemon_6_Level";
             this.CB_Pokemon_6_Level.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Level.TabIndex = 23;
@@ -2056,7 +2056,7 @@
             // L_Pokemon_6_Pokemon
             // 
             this.L_Pokemon_6_Pokemon.AutoSize = true;
-            this.L_Pokemon_6_Pokemon.Location = new System.Drawing.Point(11, 9);
+            this.L_Pokemon_6_Pokemon.Location = new System.Drawing.Point(11, 17);
             this.L_Pokemon_6_Pokemon.Name = "L_Pokemon_6_Pokemon";
             this.L_Pokemon_6_Pokemon.Size = new System.Drawing.Size(55, 13);
             this.L_Pokemon_6_Pokemon.TabIndex = 22;
@@ -2068,7 +2068,7 @@
             this.CB_Pokemon_6_Pokemon.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Pokemon_6_Pokemon.Enabled = false;
             this.CB_Pokemon_6_Pokemon.FormattingEnabled = true;
-            this.CB_Pokemon_6_Pokemon.Location = new System.Drawing.Point(72, 6);
+            this.CB_Pokemon_6_Pokemon.Location = new System.Drawing.Point(72, 14);
             this.CB_Pokemon_6_Pokemon.Name = "CB_Pokemon_6_Pokemon";
             this.CB_Pokemon_6_Pokemon.Size = new System.Drawing.Size(121, 21);
             this.CB_Pokemon_6_Pokemon.TabIndex = 21;

--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -717,7 +717,7 @@ namespace pk3DS
                 }
 
                 // high-power attacks
-                if (rForceHighPower && pk.Level >= rForceHighPowerLevel && !rMetronome)
+                if (rForceHighPower && pk.Level >= rForceHighPowerLevel)
                 {
                     var pkMoves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
                     for (int m = 0; m < 4; m++)

--- a/pk3DS/Subforms/Gen6/TrainerRand.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.cs
@@ -118,7 +118,7 @@ namespace pk3DS
             GB_Tweak.Enabled = 
                 CHK_G1.Checked = CHK_G2.Checked = CHK_G3.Checked = 
                 CHK_G4.Checked = CHK_G5.Checked = CHK_G6.Checked = 
-                CHK_L.Checked = CHK_E.Checked = CHK_StoryMEvos.Checked = 
+                CHK_L.Checked = CHK_E.Checked = CHK_StoryMEvos.Checked = CHK_ForceFullyEvolved.Checked =
                 CHK_RandomPKM.Checked;
 
             CHK_TypeTheme.Checked = CHK_GymTrainers.Checked = CHK_GymE4Only.Checked = 
@@ -162,8 +162,8 @@ namespace pk3DS
             CHK_Damage.Enabled = CHK_STAB.Enabled =
             NUD_Damage.Enabled = NUD_STAB.Enabled = CB_Moves.SelectedIndex == 1;
 
-            //if (CB_Moves.SelectedIndex == 0)
-            //    CHK_6PKM.Checked = false;
+            CHK_ForceHighPower.Enabled = CHK_ForceHighPower.Checked = NUD_ForceHighPower.Enabled =
+            CHK_NoFixedDamage.Enabled = CHK_NoFixedDamage.Checked = (CB_Moves.SelectedIndex == 1 || CB_Moves.SelectedIndex == 2);
         }
         private void CHK_6PKM_CheckedChanged(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/EggMoveEditor7.cs
+++ b/pk3DS/Subforms/Gen7/EggMoveEditor7.cs
@@ -138,7 +138,7 @@ namespace pk3DS
             rand.Execute();
             // sets.Select(z => z.Write()).ToArray().CopyTo(files, 0);
             getList();
-            WinFormsUtil.Alert("All Pokémon's Egg Moves have been randomized!");
+            WinFormsUtil.Alert("All Pokémon's Egg Moves have been randomized!", "Press the Dump All button to see the new Egg Moves!");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/LevelUpEditor7.cs
+++ b/pk3DS/Subforms/Gen7/LevelUpEditor7.cs
@@ -152,10 +152,12 @@ namespace pk3DS
             rand.Execute();
             sets.Select(z => z.Write()).ToArray().CopyTo(files, 0);
             getList();
-            WinFormsUtil.Alert("All Pokémon's Level Up Moves have been randomized!");
+            WinFormsUtil.Alert("All Pokémon's Level Up Moves have been randomized!", "Press the Dump button to see the new Level Up Moves!");
         }
         private void B_Metronome_Click(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Play using Metronome Mode?", "This will modify learnsets to only have Metronome.") != DialogResult.Yes) return;
+
             // clear all data, then only assign Metronome at Lv1
             for (int i = 0; i < CB_Species.Items.Count; i++)
             {
@@ -166,7 +168,7 @@ namespace pk3DS
                 dgv.Rows[0].Cells[1].Value = movelist[118];
             }
             CB_Species.SelectedIndex = 0;
-            WinFormsUtil.Alert("All Pokémon now only know the move Metronome!", "It is recommended that you open the Move Editor and set the Base PP for Metronome to 40.");
+            WinFormsUtil.Alert("All Pokémon now only know the move Metronome!");
         }
         private void B_Dump_Click(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
@@ -32,8 +32,11 @@
             this.L_Species_Precursor = new System.Windows.Forms.Label();
             this.TC_Pokemon = new System.Windows.Forms.TabControl();
             this.TP_General = new System.Windows.Forms.TabPage();
+            this.L_HiddenAbility = new System.Windows.Forms.Label();
             this.L_WeightKG = new System.Windows.Forms.Label();
+            this.L_Ability2 = new System.Windows.Forms.Label();
             this.L_HeightM = new System.Windows.Forms.Label();
+            this.L_Ability1 = new System.Windows.Forms.Label();
             this.TB_Weight = new System.Windows.Forms.MaskedTextBox();
             this.TB_Height = new System.Windows.Forms.MaskedTextBox();
             this.L_Weight = new System.Windows.Forms.Label();
@@ -46,7 +49,6 @@
             this.CHK_Variant = new System.Windows.Forms.CheckBox();
             this.TB_BST = new System.Windows.Forms.TextBox();
             this.L_BST = new System.Windows.Forms.Label();
-            this.TB_RawColor = new System.Windows.Forms.TextBox();
             this.TB_CatchRate = new System.Windows.Forms.MaskedTextBox();
             this.TB_Stage = new System.Windows.Forms.TextBox();
             this.L_Stage = new System.Windows.Forms.Label();
@@ -104,9 +106,9 @@
             this.Label_SPE = new System.Windows.Forms.Label();
             this.L_EVYield = new System.Windows.Forms.Label();
             this.L_BaseStats = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
+            this.L_ZMove = new System.Windows.Forms.Label();
             this.L_BaseMove = new System.Windows.Forms.Label();
-            this.L_ZItem = new System.Windows.Forms.Label();
+            this.L_ZCrystal = new System.Windows.Forms.Label();
             this.TP_MoveTutors = new System.Windows.Forms.TabPage();
             this.L_BeachTutors = new System.Windows.Forms.Label();
             this.CLB_BeachTutors = new System.Windows.Forms.CheckedListBox();
@@ -116,13 +118,14 @@
             this.CLB_TM = new System.Windows.Forms.CheckedListBox();
             this.TP_Randomizer = new System.Windows.Forms.TabPage();
             this.GB_Modifier = new System.Windows.Forms.GroupBox();
+            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.CHK_CatchRateMod = new System.Windows.Forms.CheckBox();
             this.L_CatchRateMod = new System.Windows.Forms.Label();
             this.NUD_CatchRateMod = new System.Windows.Forms.NumericUpDown();
             this.CHK_CallRate = new System.Windows.Forms.CheckBox();
-            this.L_CallRateVal = new System.Windows.Forms.Label();
             this.NUD_CallRate = new System.Windows.Forms.NumericUpDown();
             this.CHK_EXP = new System.Windows.Forms.CheckBox();
+            this.L_CallRateVal = new System.Windows.Forms.Label();
             this.CHK_Growth = new System.Windows.Forms.CheckBox();
             this.CHK_QuickHatch = new System.Windows.Forms.CheckBox();
             this.L_FinalXP = new System.Windows.Forms.Label();
@@ -146,7 +149,6 @@
             this.CHK_rATK = new System.Windows.Forms.CheckBox();
             this.NUD_TypePercent = new System.Windows.Forms.NumericUpDown();
             this.CHK_rHP = new System.Windows.Forms.CheckBox();
-            this.CHK_HM = new System.Windows.Forms.CheckBox();
             this.L_StatDev = new System.Windows.Forms.Label();
             this.CHK_TM = new System.Windows.Forms.CheckBox();
             this.NUD_StatDev = new System.Windows.Forms.NumericUpDown();
@@ -157,7 +159,6 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
-            this.CHK_NoTutor = new System.Windows.Forms.CheckBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -208,8 +209,11 @@
             // 
             // TP_General
             // 
+            this.TP_General.Controls.Add(this.L_HiddenAbility);
             this.TP_General.Controls.Add(this.L_WeightKG);
+            this.TP_General.Controls.Add(this.L_Ability2);
             this.TP_General.Controls.Add(this.L_HeightM);
+            this.TP_General.Controls.Add(this.L_Ability1);
             this.TP_General.Controls.Add(this.TB_Weight);
             this.TP_General.Controls.Add(this.TB_Height);
             this.TP_General.Controls.Add(this.L_Weight);
@@ -222,7 +226,6 @@
             this.TP_General.Controls.Add(this.CHK_Variant);
             this.TP_General.Controls.Add(this.TB_BST);
             this.TP_General.Controls.Add(this.L_BST);
-            this.TP_General.Controls.Add(this.TB_RawColor);
             this.TP_General.Controls.Add(this.TB_CatchRate);
             this.TP_General.Controls.Add(this.TB_Stage);
             this.TP_General.Controls.Add(this.L_Stage);
@@ -280,9 +283,9 @@
             this.TP_General.Controls.Add(this.Label_SPE);
             this.TP_General.Controls.Add(this.L_EVYield);
             this.TP_General.Controls.Add(this.L_BaseStats);
-            this.TP_General.Controls.Add(this.label1);
+            this.TP_General.Controls.Add(this.L_ZMove);
             this.TP_General.Controls.Add(this.L_BaseMove);
-            this.TP_General.Controls.Add(this.L_ZItem);
+            this.TP_General.Controls.Add(this.L_ZCrystal);
             this.TP_General.Location = new System.Drawing.Point(4, 22);
             this.TP_General.Name = "TP_General";
             this.TP_General.Padding = new System.Windows.Forms.Padding(3);
@@ -291,48 +294,75 @@
             this.TP_General.Text = "General Info";
             this.TP_General.UseVisualStyleBackColor = true;
             // 
+            // L_HiddenAbility
+            // 
+            this.L_HiddenAbility.AutoSize = true;
+            this.L_HiddenAbility.Location = new System.Drawing.Point(413, 126);
+            this.L_HiddenAbility.Name = "L_HiddenAbility";
+            this.L_HiddenAbility.Size = new System.Drawing.Size(21, 13);
+            this.L_HiddenAbility.TabIndex = 421;
+            this.L_HiddenAbility.Text = "(H)";
+            // 
             // L_WeightKG
             // 
             this.L_WeightKG.AutoSize = true;
-            this.L_WeightKG.Location = new System.Drawing.Point(415, 322);
+            this.L_WeightKG.Location = new System.Drawing.Point(416, 326);
             this.L_WeightKG.Name = "L_WeightKG";
             this.L_WeightKG.Size = new System.Drawing.Size(19, 13);
             this.L_WeightKG.TabIndex = 105;
             this.L_WeightKG.Text = "kg";
             // 
+            // L_Ability2
+            // 
+            this.L_Ability2.AutoSize = true;
+            this.L_Ability2.Location = new System.Drawing.Point(414, 104);
+            this.L_Ability2.Name = "L_Ability2";
+            this.L_Ability2.Size = new System.Drawing.Size(19, 13);
+            this.L_Ability2.TabIndex = 420;
+            this.L_Ability2.Text = "(2)";
+            // 
             // L_HeightM
             // 
             this.L_HeightM.AutoSize = true;
-            this.L_HeightM.Location = new System.Drawing.Point(415, 302);
+            this.L_HeightM.Location = new System.Drawing.Point(416, 305);
             this.L_HeightM.Name = "L_HeightM";
             this.L_HeightM.Size = new System.Drawing.Size(15, 13);
             this.L_HeightM.TabIndex = 104;
             this.L_HeightM.Text = "m";
             // 
+            // L_Ability1
+            // 
+            this.L_Ability1.AutoSize = true;
+            this.L_Ability1.Location = new System.Drawing.Point(414, 82);
+            this.L_Ability1.Name = "L_Ability1";
+            this.L_Ability1.Size = new System.Drawing.Size(19, 13);
+            this.L_Ability1.TabIndex = 419;
+            this.L_Ability1.Text = "(1)";
+            // 
             // TB_Weight
             // 
             this.TB_Weight.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Weight.Location = new System.Drawing.Point(381, 318);
+            this.TB_Weight.Location = new System.Drawing.Point(384, 322);
             this.TB_Weight.Mask = "000.0";
             this.TB_Weight.Name = "TB_Weight";
-            this.TB_Weight.Size = new System.Drawing.Size(31, 20);
+            this.TB_Weight.Size = new System.Drawing.Size(32, 20);
             this.TB_Weight.TabIndex = 103;
             this.TB_Weight.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // TB_Height
             // 
             this.TB_Height.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Height.Location = new System.Drawing.Point(381, 298);
+            this.TB_Height.Location = new System.Drawing.Point(384, 301);
             this.TB_Height.Mask = "00.0";
             this.TB_Height.Name = "TB_Height";
-            this.TB_Height.Size = new System.Drawing.Size(31, 20);
+            this.TB_Height.Size = new System.Drawing.Size(32, 20);
             this.TB_Height.TabIndex = 102;
             this.TB_Height.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_Weight
             // 
             this.L_Weight.AutoSize = true;
-            this.L_Weight.Location = new System.Drawing.Point(336, 322);
+            this.L_Weight.Location = new System.Drawing.Point(340, 325);
             this.L_Weight.Name = "L_Weight";
             this.L_Weight.Size = new System.Drawing.Size(44, 13);
             this.L_Weight.TabIndex = 101;
@@ -342,7 +372,7 @@
             // L_Height
             // 
             this.L_Height.AutoSize = true;
-            this.L_Height.Location = new System.Drawing.Point(339, 302);
+            this.L_Height.Location = new System.Drawing.Point(343, 304);
             this.L_Height.Name = "L_Height";
             this.L_Height.Size = new System.Drawing.Size(41, 13);
             this.L_Height.TabIndex = 100;
@@ -352,7 +382,7 @@
             // CB_ZMove
             // 
             this.CB_ZMove.FormattingEnabled = true;
-            this.CB_ZMove.Location = new System.Drawing.Point(177, 320);
+            this.CB_ZMove.Location = new System.Drawing.Point(177, 321);
             this.CB_ZMove.Name = "CB_ZMove";
             this.CB_ZMove.Size = new System.Drawing.Size(121, 21);
             this.CB_ZMove.TabIndex = 98;
@@ -368,7 +398,7 @@
             // CB_ZItem
             // 
             this.CB_ZItem.FormattingEnabled = true;
-            this.CB_ZItem.Location = new System.Drawing.Point(177, 278);
+            this.CB_ZItem.Location = new System.Drawing.Point(177, 277);
             this.CB_ZItem.Name = "CB_ZItem";
             this.CB_ZItem.Size = new System.Drawing.Size(121, 21);
             this.CB_ZItem.TabIndex = 94;
@@ -376,7 +406,7 @@
             // TB_CallRate
             // 
             this.TB_CallRate.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_CallRate.Location = new System.Drawing.Point(77, 278);
+            this.TB_CallRate.Location = new System.Drawing.Point(77, 281);
             this.TB_CallRate.Mask = "000";
             this.TB_CallRate.Name = "TB_CallRate";
             this.TB_CallRate.Size = new System.Drawing.Size(31, 20);
@@ -387,7 +417,7 @@
             // L_CallRate
             // 
             this.L_CallRate.AutoSize = true;
-            this.L_CallRate.Location = new System.Drawing.Point(23, 282);
+            this.L_CallRate.Location = new System.Drawing.Point(23, 285);
             this.L_CallRate.Name = "L_CallRate";
             this.L_CallRate.Size = new System.Drawing.Size(53, 13);
             this.L_CallRate.TabIndex = 92;
@@ -397,8 +427,7 @@
             // CHK_Variant
             // 
             this.CHK_Variant.AutoSize = true;
-            this.CHK_Variant.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.CHK_Variant.Location = new System.Drawing.Point(178, 261);
+            this.CHK_Variant.Location = new System.Drawing.Point(185, 259);
             this.CHK_Variant.Name = "CHK_Variant";
             this.CHK_Variant.Size = new System.Drawing.Size(104, 17);
             this.CHK_Variant.TabIndex = 91;
@@ -425,16 +454,6 @@
             this.L_BST.Text = "BST:";
             this.L_BST.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // TB_RawColor
-            // 
-            this.TB_RawColor.Location = new System.Drawing.Point(382, 211);
-            this.TB_RawColor.Name = "TB_RawColor";
-            this.TB_RawColor.ReadOnly = true;
-            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
-            this.TB_RawColor.TabIndex = 88;
-            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.TB_RawColor.Visible = false;
-            // 
             // TB_CatchRate
             // 
             this.TB_CatchRate.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -448,17 +467,17 @@
             // 
             // TB_Stage
             // 
-            this.TB_Stage.Location = new System.Drawing.Point(382, 238);
+            this.TB_Stage.Location = new System.Drawing.Point(384, 238);
             this.TB_Stage.Name = "TB_Stage";
             this.TB_Stage.ReadOnly = true;
-            this.TB_Stage.Size = new System.Drawing.Size(30, 20);
+            this.TB_Stage.Size = new System.Drawing.Size(32, 20);
             this.TB_Stage.TabIndex = 86;
             this.TB_Stage.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_Stage
             // 
             this.L_Stage.AutoSize = true;
-            this.L_Stage.Location = new System.Drawing.Point(296, 241);
+            this.L_Stage.Location = new System.Drawing.Point(299, 240);
             this.L_Stage.Name = "L_Stage";
             this.L_Stage.Size = new System.Drawing.Size(85, 13);
             this.L_Stage.TabIndex = 85;
@@ -467,17 +486,17 @@
             // 
             // TB_FormeCount
             // 
-            this.TB_FormeCount.Location = new System.Drawing.Point(382, 278);
+            this.TB_FormeCount.Location = new System.Drawing.Point(384, 280);
             this.TB_FormeCount.Name = "TB_FormeCount";
             this.TB_FormeCount.ReadOnly = true;
-            this.TB_FormeCount.Size = new System.Drawing.Size(30, 20);
+            this.TB_FormeCount.Size = new System.Drawing.Size(32, 20);
             this.TB_FormeCount.TabIndex = 82;
             this.TB_FormeCount.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_FormesCount
             // 
             this.L_FormesCount.AutoSize = true;
-            this.L_FormesCount.Location = new System.Drawing.Point(306, 282);
+            this.L_FormesCount.Location = new System.Drawing.Point(309, 283);
             this.L_FormesCount.Name = "L_FormesCount";
             this.L_FormesCount.Size = new System.Drawing.Size(75, 13);
             this.L_FormesCount.TabIndex = 81;
@@ -486,17 +505,17 @@
             // 
             // TB_FormeSprite
             // 
-            this.TB_FormeSprite.Location = new System.Drawing.Point(382, 258);
+            this.TB_FormeSprite.Location = new System.Drawing.Point(384, 259);
             this.TB_FormeSprite.Name = "TB_FormeSprite";
             this.TB_FormeSprite.ReadOnly = true;
-            this.TB_FormeSprite.Size = new System.Drawing.Size(30, 20);
+            this.TB_FormeSprite.Size = new System.Drawing.Size(32, 20);
             this.TB_FormeSprite.TabIndex = 80;
             this.TB_FormeSprite.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // L_FormeSprite
             // 
             this.L_FormeSprite.AutoSize = true;
-            this.L_FormeSprite.Location = new System.Drawing.Point(312, 262);
+            this.L_FormeSprite.Location = new System.Drawing.Point(315, 262);
             this.L_FormeSprite.Name = "L_FormeSprite";
             this.L_FormeSprite.Size = new System.Drawing.Size(69, 13);
             this.L_FormeSprite.TabIndex = 79;
@@ -517,9 +536,9 @@
             this.CB_Color.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Color.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Color.FormattingEnabled = true;
-            this.CB_Color.Location = new System.Drawing.Point(295, 211);
+            this.CB_Color.Location = new System.Drawing.Point(295, 209);
             this.CB_Color.Name = "CB_Color";
-            this.CB_Color.Size = new System.Drawing.Size(86, 21);
+            this.CB_Color.Size = new System.Drawing.Size(121, 21);
             this.CB_Color.TabIndex = 76;
             // 
             // CB_EXPGroup
@@ -535,7 +554,7 @@
             // L_Color
             // 
             this.L_Color.AutoSize = true;
-            this.L_Color.Location = new System.Drawing.Point(260, 214);
+            this.L_Color.Location = new System.Drawing.Point(261, 211);
             this.L_Color.Name = "L_Color";
             this.L_Color.Size = new System.Drawing.Size(34, 13);
             this.L_Color.TabIndex = 74;
@@ -544,7 +563,7 @@
             // L_EXPGrowth
             // 
             this.L_EXPGrowth.AutoSize = true;
-            this.L_EXPGrowth.Location = new System.Drawing.Point(16, 214);
+            this.L_EXPGrowth.Location = new System.Drawing.Point(16, 213);
             this.L_EXPGrowth.Name = "L_EXPGrowth";
             this.L_EXPGrowth.Size = new System.Drawing.Size(63, 13);
             this.L_EXPGrowth.TabIndex = 73;
@@ -555,7 +574,7 @@
             this.CB_Ability3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability3.FormattingEnabled = true;
-            this.CB_Ability3.Location = new System.Drawing.Point(276, 131);
+            this.CB_Ability3.Location = new System.Drawing.Point(272, 123);
             this.CB_Ability3.Name = "CB_Ability3";
             this.CB_Ability3.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability3.TabIndex = 68;
@@ -565,7 +584,7 @@
             this.CB_Ability2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability2.FormattingEnabled = true;
-            this.CB_Ability2.Location = new System.Drawing.Point(276, 105);
+            this.CB_Ability2.Location = new System.Drawing.Point(272, 101);
             this.CB_Ability2.Name = "CB_Ability2";
             this.CB_Ability2.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability2.TabIndex = 67;
@@ -575,7 +594,7 @@
             this.CB_Ability1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Ability1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Ability1.FormattingEnabled = true;
-            this.CB_Ability1.Location = new System.Drawing.Point(276, 79);
+            this.CB_Ability1.Location = new System.Drawing.Point(272, 79);
             this.CB_Ability1.Name = "CB_Ability1";
             this.CB_Ability1.Size = new System.Drawing.Size(140, 21);
             this.CB_Ability1.TabIndex = 66;
@@ -585,7 +604,7 @@
             this.CB_EggGroup2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_EggGroup2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EggGroup2.FormattingEnabled = true;
-            this.CB_EggGroup2.Location = new System.Drawing.Point(295, 184);
+            this.CB_EggGroup2.Location = new System.Drawing.Point(295, 180);
             this.CB_EggGroup2.Name = "CB_EggGroup2";
             this.CB_EggGroup2.Size = new System.Drawing.Size(121, 21);
             this.CB_EggGroup2.TabIndex = 65;
@@ -612,7 +631,7 @@
             // L_Ability
             // 
             this.L_Ability.AutoSize = true;
-            this.L_Ability.Location = new System.Drawing.Point(230, 83);
+            this.L_Ability.Location = new System.Drawing.Point(226, 83);
             this.L_Ability.Name = "L_Ability";
             this.L_Ability.Size = new System.Drawing.Size(45, 13);
             this.L_Ability.TabIndex = 62;
@@ -621,7 +640,7 @@
             // TB_BaseExp
             // 
             this.TB_BaseExp.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_BaseExp.Location = new System.Drawing.Point(77, 298);
+            this.TB_BaseExp.Location = new System.Drawing.Point(77, 302);
             this.TB_BaseExp.Mask = "000";
             this.TB_BaseExp.Name = "TB_BaseExp";
             this.TB_BaseExp.Size = new System.Drawing.Size(31, 20);
@@ -632,7 +651,7 @@
             // L_BaseEXP
             // 
             this.L_BaseEXP.AutoSize = true;
-            this.L_BaseEXP.Location = new System.Drawing.Point(18, 302);
+            this.L_BaseEXP.Location = new System.Drawing.Point(18, 306);
             this.L_BaseEXP.Name = "L_BaseEXP";
             this.L_BaseEXP.Size = new System.Drawing.Size(58, 13);
             this.L_BaseEXP.TabIndex = 60;
@@ -642,7 +661,7 @@
             // TB_HatchCycles
             // 
             this.TB_HatchCycles.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_HatchCycles.Location = new System.Drawing.Point(77, 318);
+            this.TB_HatchCycles.Location = new System.Drawing.Point(77, 323);
             this.TB_HatchCycles.Mask = "000";
             this.TB_HatchCycles.Name = "TB_HatchCycles";
             this.TB_HatchCycles.Size = new System.Drawing.Size(31, 20);
@@ -653,7 +672,7 @@
             // L_HatchCycles
             // 
             this.L_HatchCycles.AutoSize = true;
-            this.L_HatchCycles.Location = new System.Drawing.Point(3, 321);
+            this.L_HatchCycles.Location = new System.Drawing.Point(3, 326);
             this.L_HatchCycles.Name = "L_HatchCycles";
             this.L_HatchCycles.Size = new System.Drawing.Size(73, 13);
             this.L_HatchCycles.TabIndex = 57;
@@ -663,7 +682,7 @@
             // TB_Friendship
             // 
             this.TB_Friendship.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Friendship.Location = new System.Drawing.Point(77, 258);
+            this.TB_Friendship.Location = new System.Drawing.Point(77, 260);
             this.TB_Friendship.Mask = "000";
             this.TB_Friendship.Name = "TB_Friendship";
             this.TB_Friendship.Size = new System.Drawing.Size(31, 20);
@@ -674,7 +693,7 @@
             // TB_Gender
             // 
             this.TB_Gender.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.TB_Gender.Location = new System.Drawing.Point(77, 238);
+            this.TB_Gender.Location = new System.Drawing.Point(77, 239);
             this.TB_Gender.Mask = "000";
             this.TB_Gender.Name = "TB_Gender";
             this.TB_Gender.Size = new System.Drawing.Size(31, 20);
@@ -685,7 +704,7 @@
             // L_Friendship
             // 
             this.L_Friendship.AutoSize = true;
-            this.L_Friendship.Location = new System.Drawing.Point(18, 262);
+            this.L_Friendship.Location = new System.Drawing.Point(18, 264);
             this.L_Friendship.Name = "L_Friendship";
             this.L_Friendship.Size = new System.Drawing.Size(58, 13);
             this.L_Friendship.TabIndex = 54;
@@ -695,7 +714,7 @@
             // L_Gender
             // 
             this.L_Gender.AutoSize = true;
-            this.L_Gender.Location = new System.Drawing.Point(31, 241);
+            this.L_Gender.Location = new System.Drawing.Point(31, 242);
             this.L_Gender.Name = "L_Gender";
             this.L_Gender.Size = new System.Drawing.Size(45, 13);
             this.L_Gender.TabIndex = 53;
@@ -705,7 +724,7 @@
             // L_Item1
             // 
             this.L_Item1.AutoSize = true;
-            this.L_Item1.Location = new System.Drawing.Point(195, 134);
+            this.L_Item1.Location = new System.Drawing.Point(195, 126);
             this.L_Item1.Name = "L_Item1";
             this.L_Item1.Size = new System.Drawing.Size(21, 13);
             this.L_Item1.TabIndex = 52;
@@ -714,7 +733,7 @@
             // L_Item5
             // 
             this.L_Item5.AutoSize = true;
-            this.L_Item5.Location = new System.Drawing.Point(195, 107);
+            this.L_Item5.Location = new System.Drawing.Point(195, 104);
             this.L_Item5.Name = "L_Item5";
             this.L_Item5.Size = new System.Drawing.Size(21, 13);
             this.L_Item5.TabIndex = 51;
@@ -734,7 +753,7 @@
             this.CB_HeldItem3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_HeldItem3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_HeldItem3.FormattingEnabled = true;
-            this.CB_HeldItem3.Location = new System.Drawing.Point(52, 131);
+            this.CB_HeldItem3.Location = new System.Drawing.Point(52, 123);
             this.CB_HeldItem3.Name = "CB_HeldItem3";
             this.CB_HeldItem3.Size = new System.Drawing.Size(140, 21);
             this.CB_HeldItem3.TabIndex = 49;
@@ -744,7 +763,7 @@
             this.CB_HeldItem2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_HeldItem2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_HeldItem2.FormattingEnabled = true;
-            this.CB_HeldItem2.Location = new System.Drawing.Point(52, 105);
+            this.CB_HeldItem2.Location = new System.Drawing.Point(52, 101);
             this.CB_HeldItem2.Name = "CB_HeldItem2";
             this.CB_HeldItem2.Size = new System.Drawing.Size(140, 21);
             this.CB_HeldItem2.TabIndex = 48;
@@ -773,7 +792,7 @@
             this.CB_Type2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.CB_Type2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Type2.FormattingEnabled = true;
-            this.CB_Type2.Location = new System.Drawing.Point(63, 184);
+            this.CB_Type2.Location = new System.Drawing.Point(63, 180);
             this.CB_Type2.Name = "CB_Type2";
             this.CB_Type2.Size = new System.Drawing.Size(129, 21);
             this.CB_Type2.TabIndex = 45;
@@ -1001,32 +1020,32 @@
             this.L_BaseStats.TabIndex = 1;
             this.L_BaseStats.Text = "Base Stats:";
             // 
-            // label1
+            // L_ZMove
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(134, 323);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(44, 13);
-            this.label1.TabIndex = 99;
-            this.label1.Text = "Z Move";
+            this.L_ZMove.AutoSize = true;
+            this.L_ZMove.Location = new System.Drawing.Point(130, 324);
+            this.L_ZMove.Name = "L_ZMove";
+            this.L_ZMove.Size = new System.Drawing.Size(47, 13);
+            this.L_ZMove.TabIndex = 99;
+            this.L_ZMove.Text = "Z-Move:";
             // 
             // L_BaseMove
             // 
             this.L_BaseMove.AutoSize = true;
-            this.L_BaseMove.Location = new System.Drawing.Point(116, 302);
+            this.L_BaseMove.Location = new System.Drawing.Point(113, 303);
             this.L_BaseMove.Name = "L_BaseMove";
-            this.L_BaseMove.Size = new System.Drawing.Size(61, 13);
+            this.L_BaseMove.Size = new System.Drawing.Size(64, 13);
             this.L_BaseMove.TabIndex = 97;
-            this.L_BaseMove.Text = "Base Move";
+            this.L_BaseMove.Text = "Base Move:";
             // 
-            // L_ZItem
+            // L_ZCrystal
             // 
-            this.L_ZItem.AutoSize = true;
-            this.L_ZItem.Location = new System.Drawing.Point(140, 281);
-            this.L_ZItem.Name = "L_ZItem";
-            this.L_ZItem.Size = new System.Drawing.Size(37, 13);
-            this.L_ZItem.TabIndex = 96;
-            this.L_ZItem.Text = "Z Item";
+            this.L_ZCrystal.AutoSize = true;
+            this.L_ZCrystal.Location = new System.Drawing.Point(126, 281);
+            this.L_ZCrystal.Name = "L_ZCrystal";
+            this.L_ZCrystal.Size = new System.Drawing.Size(51, 13);
+            this.L_ZCrystal.TabIndex = 96;
+            this.L_ZCrystal.Text = "Z-Crystal:";
             // 
             // TP_MoveTutors
             // 
@@ -1049,9 +1068,9 @@
             this.L_BeachTutors.AutoSize = true;
             this.L_BeachTutors.Location = new System.Drawing.Point(298, 3);
             this.L_BeachTutors.Name = "L_BeachTutors";
-            this.L_BeachTutors.Size = new System.Drawing.Size(40, 13);
+            this.L_BeachTutors.Size = new System.Drawing.Size(74, 13);
             this.L_BeachTutors.TabIndex = 9;
-            this.L_BeachTutors.Text = "Tutors:";
+            this.L_BeachTutors.Text = "Beach Tutors:";
             this.L_BeachTutors.Visible = false;
             // 
             // CLB_BeachTutors
@@ -1080,9 +1099,9 @@
             this.L_TM.AutoSize = true;
             this.L_TM.Location = new System.Drawing.Point(6, 3);
             this.L_TM.Name = "L_TM";
-            this.L_TM.Size = new System.Drawing.Size(26, 13);
+            this.L_TM.Size = new System.Drawing.Size(31, 13);
             this.L_TM.TabIndex = 5;
-            this.L_TM.Text = "TM:";
+            this.L_TM.Text = "TMs:";
             // 
             // CLB_MoveTutors
             // 
@@ -1124,9 +1143,9 @@
             this.GB_Modifier.Controls.Add(this.L_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.NUD_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.CHK_CallRate);
-            this.GB_Modifier.Controls.Add(this.L_CallRateVal);
             this.GB_Modifier.Controls.Add(this.NUD_CallRate);
             this.GB_Modifier.Controls.Add(this.CHK_EXP);
+            this.GB_Modifier.Controls.Add(this.L_CallRateVal);
             this.GB_Modifier.Controls.Add(this.CHK_Growth);
             this.GB_Modifier.Controls.Add(this.CHK_QuickHatch);
             this.GB_Modifier.Controls.Add(this.L_FinalXP);
@@ -1139,10 +1158,20 @@
             this.GB_Modifier.TabStop = false;
             this.GB_Modifier.Text = "Modifier Options";
             // 
+            // CHK_NoTutor
+            // 
+            this.CHK_NoTutor.AutoSize = true;
+            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
+            this.CHK_NoTutor.Name = "CHK_NoTutor";
+            this.CHK_NoTutor.Size = new System.Drawing.Size(176, 30);
+            this.CHK_NoTutor.TabIndex = 21;
+            this.CHK_NoTutor.Text = "Remove All TM/Move Tutor\nCompatibility (Metronome Mode)";
+            this.CHK_NoTutor.UseVisualStyleBackColor = true;
+            // 
             // CHK_CatchRateMod
             // 
             this.CHK_CatchRateMod.AutoSize = true;
-            this.CHK_CatchRateMod.Location = new System.Drawing.Point(204, 81);
+            this.CHK_CatchRateMod.Location = new System.Drawing.Point(204, 38);
             this.CHK_CatchRateMod.Name = "CHK_CatchRateMod";
             this.CHK_CatchRateMod.Size = new System.Drawing.Size(114, 17);
             this.CHK_CatchRateMod.TabIndex = 16;
@@ -1152,7 +1181,7 @@
             // L_CatchRateMod
             // 
             this.L_CatchRateMod.AutoSize = true;
-            this.L_CatchRateMod.Location = new System.Drawing.Point(204, 101);
+            this.L_CatchRateMod.Location = new System.Drawing.Point(230, 58);
             this.L_CatchRateMod.Name = "L_CatchRateMod";
             this.L_CatchRateMod.Size = new System.Drawing.Size(34, 13);
             this.L_CatchRateMod.TabIndex = 15;
@@ -1160,7 +1189,7 @@
             // 
             // NUD_CatchRateMod
             // 
-            this.NUD_CatchRateMod.Location = new System.Drawing.Point(267, 99);
+            this.NUD_CatchRateMod.Location = new System.Drawing.Point(267, 56);
             this.NUD_CatchRateMod.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1183,25 +1212,16 @@
             // CHK_CallRate
             // 
             this.CHK_CallRate.AutoSize = true;
-            this.CHK_CallRate.Location = new System.Drawing.Point(204, 38);
+            this.CHK_CallRate.Location = new System.Drawing.Point(204, 80);
             this.CHK_CallRate.Name = "CHK_CallRate";
             this.CHK_CallRate.Size = new System.Drawing.Size(128, 17);
             this.CHK_CallRate.TabIndex = 13;
             this.CHK_CallRate.Text = "Modify SOS Call Rate";
             this.CHK_CallRate.UseVisualStyleBackColor = true;
             // 
-            // L_CallRateVal
-            // 
-            this.L_CallRateVal.AutoSize = true;
-            this.L_CallRateVal.Location = new System.Drawing.Point(204, 58);
-            this.L_CallRateVal.Name = "L_CallRateVal";
-            this.L_CallRateVal.Size = new System.Drawing.Size(34, 13);
-            this.L_CallRateVal.TabIndex = 12;
-            this.L_CallRateVal.Text = "Value";
-            // 
             // NUD_CallRate
             // 
-            this.NUD_CallRate.Location = new System.Drawing.Point(267, 56);
+            this.NUD_CallRate.Location = new System.Drawing.Point(267, 98);
             this.NUD_CallRate.Maximum = new decimal(new int[] {
             255,
             0,
@@ -1225,6 +1245,15 @@
             this.CHK_EXP.TabIndex = 7;
             this.CHK_EXP.Text = "Modify EXP Yield";
             this.CHK_EXP.UseVisualStyleBackColor = true;
+            // 
+            // L_CallRateVal
+            // 
+            this.L_CallRateVal.AutoSize = true;
+            this.L_CallRateVal.Location = new System.Drawing.Point(230, 100);
+            this.L_CallRateVal.Name = "L_CallRateVal";
+            this.L_CallRateVal.Size = new System.Drawing.Size(34, 13);
+            this.L_CallRateVal.TabIndex = 12;
+            this.L_CallRateVal.Text = "Value";
             // 
             // CHK_Growth
             // 
@@ -1251,7 +1280,7 @@
             // L_FinalXP
             // 
             this.L_FinalXP.AutoSize = true;
-            this.L_FinalXP.Location = new System.Drawing.Point(6, 71);
+            this.L_FinalXP.Location = new System.Drawing.Point(6, 74);
             this.L_FinalXP.Name = "L_FinalXP";
             this.L_FinalXP.Size = new System.Drawing.Size(63, 13);
             this.L_FinalXP.TabIndex = 6;
@@ -1259,7 +1288,7 @@
             // 
             // NUD_EXP
             // 
-            this.NUD_EXP.Location = new System.Drawing.Point(69, 69);
+            this.NUD_EXP.Location = new System.Drawing.Point(69, 72);
             this.NUD_EXP.Maximum = new decimal(new int[] {
             300,
             0,
@@ -1312,7 +1341,6 @@
             this.GB_Randomizer.Controls.Add(this.CHK_rATK);
             this.GB_Randomizer.Controls.Add(this.NUD_TypePercent);
             this.GB_Randomizer.Controls.Add(this.CHK_rHP);
-            this.GB_Randomizer.Controls.Add(this.CHK_HM);
             this.GB_Randomizer.Controls.Add(this.L_StatDev);
             this.GB_Randomizer.Controls.Add(this.CHK_TM);
             this.GB_Randomizer.Controls.Add(this.NUD_StatDev);
@@ -1322,7 +1350,7 @@
             this.GB_Randomizer.Controls.Add(this.CHK_Item);
             this.GB_Randomizer.Location = new System.Drawing.Point(4, 12);
             this.GB_Randomizer.Name = "GB_Randomizer";
-            this.GB_Randomizer.Size = new System.Drawing.Size(345, 129);
+            this.GB_Randomizer.Size = new System.Drawing.Size(345, 133);
             this.GB_Randomizer.TabIndex = 418;
             this.GB_Randomizer.TabStop = false;
             this.GB_Randomizer.Text = "Randomizer Options";
@@ -1342,15 +1370,15 @@
             // L_Same
             // 
             this.L_Same.AutoSize = true;
-            this.L_Same.Location = new System.Drawing.Point(216, 97);
+            this.L_Same.Location = new System.Drawing.Point(213, 99);
             this.L_Same.Name = "L_Same";
-            this.L_Same.Size = new System.Drawing.Size(48, 13);
+            this.L_Same.Size = new System.Drawing.Size(51, 13);
             this.L_Same.TabIndex = 23;
-            this.L_Same.Text = "Same(%)";
+            this.L_Same.Text = "Same (%)";
             // 
             // NUD_Egg
             // 
-            this.NUD_Egg.Location = new System.Drawing.Point(267, 95);
+            this.NUD_Egg.Location = new System.Drawing.Point(267, 97);
             this.NUD_Egg.Name = "NUD_Egg";
             this.NUD_Egg.Size = new System.Drawing.Size(46, 20);
             this.NUD_Egg.TabIndex = 22;
@@ -1458,11 +1486,11 @@
             // L_SingleType
             // 
             this.L_SingleType.AutoSize = true;
-            this.L_SingleType.Location = new System.Drawing.Point(115, 78);
+            this.L_SingleType.Location = new System.Drawing.Point(115, 79);
             this.L_SingleType.Name = "L_SingleType";
-            this.L_SingleType.Size = new System.Drawing.Size(77, 13);
+            this.L_SingleType.Size = new System.Drawing.Size(80, 13);
             this.L_SingleType.TabIndex = 21;
-            this.L_SingleType.Text = "Single Type(%)";
+            this.L_SingleType.Text = "Single Type (%)";
             // 
             // CHK_rDEF
             // 
@@ -1490,7 +1518,7 @@
             // 
             // NUD_TypePercent
             // 
-            this.NUD_TypePercent.Location = new System.Drawing.Point(134, 94);
+            this.NUD_TypePercent.Location = new System.Drawing.Point(134, 95);
             this.NUD_TypePercent.Name = "NUD_TypePercent";
             this.NUD_TypePercent.Size = new System.Drawing.Size(46, 20);
             this.NUD_TypePercent.TabIndex = 20;
@@ -1512,26 +1540,14 @@
             this.CHK_rHP.Text = "HP";
             this.CHK_rHP.UseVisualStyleBackColor = true;
             // 
-            // CHK_HM
-            // 
-            this.CHK_HM.AutoSize = true;
-            this.CHK_HM.Checked = true;
-            this.CHK_HM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_HM.Location = new System.Drawing.Point(267, 15);
-            this.CHK_HM.Name = "CHK_HM";
-            this.CHK_HM.Size = new System.Drawing.Size(43, 17);
-            this.CHK_HM.TabIndex = 7;
-            this.CHK_HM.Text = "HM";
-            this.CHK_HM.UseVisualStyleBackColor = true;
-            // 
             // L_StatDev
             // 
             this.L_StatDev.AutoSize = true;
-            this.L_StatDev.Location = new System.Drawing.Point(6, 90);
+            this.L_StatDev.Location = new System.Drawing.Point(6, 92);
             this.L_StatDev.Name = "L_StatDev";
-            this.L_StatDev.Size = new System.Drawing.Size(67, 13);
+            this.L_StatDev.Size = new System.Drawing.Size(70, 13);
             this.L_StatDev.TabIndex = 4;
-            this.L_StatDev.Text = "Deviance(%)";
+            this.L_StatDev.Text = "Deviance (%)";
             // 
             // CHK_TM
             // 
@@ -1540,14 +1556,14 @@
             this.CHK_TM.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CHK_TM.Location = new System.Drawing.Point(219, 15);
             this.CHK_TM.Name = "CHK_TM";
-            this.CHK_TM.Size = new System.Drawing.Size(42, 17);
+            this.CHK_TM.Size = new System.Drawing.Size(103, 17);
             this.CHK_TM.TabIndex = 0;
-            this.CHK_TM.Text = "TM";
+            this.CHK_TM.Text = "TM Compatibility";
             this.CHK_TM.UseVisualStyleBackColor = true;
             // 
             // NUD_StatDev
             // 
-            this.NUD_StatDev.Location = new System.Drawing.Point(27, 106);
+            this.NUD_StatDev.Location = new System.Drawing.Point(27, 108);
             this.NUD_StatDev.Name = "NUD_StatDev";
             this.NUD_StatDev.Size = new System.Drawing.Size(46, 20);
             this.NUD_StatDev.TabIndex = 3;
@@ -1618,7 +1634,7 @@
             // 
             // PB_MonSprite
             // 
-            this.PB_MonSprite.Location = new System.Drawing.Point(285, 0);
+            this.PB_MonSprite.Location = new System.Drawing.Point(285, 1);
             this.PB_MonSprite.Name = "PB_MonSprite";
             this.PB_MonSprite.Size = new System.Drawing.Size(80, 60);
             this.PB_MonSprite.TabIndex = 89;
@@ -1626,23 +1642,13 @@
             // 
             // B_Dump
             // 
-            this.B_Dump.Location = new System.Drawing.Point(368, 10);
+            this.B_Dump.Location = new System.Drawing.Point(368, 19);
             this.B_Dump.Name = "B_Dump";
             this.B_Dump.Size = new System.Drawing.Size(82, 23);
             this.B_Dump.TabIndex = 418;
             this.B_Dump.Text = "Dump All";
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
-            // 
-            // CHK_NoTutor
-            // 
-            this.CHK_NoTutor.AutoSize = true;
-            this.CHK_NoTutor.Location = new System.Drawing.Point(6, 95);
-            this.CHK_NoTutor.Name = "CHK_NoTutor";
-            this.CHK_NoTutor.Size = new System.Drawing.Size(190, 17);
-            this.CHK_NoTutor.TabIndex = 21;
-            this.CHK_NoTutor.Text = "Remove All TM/Tutor Compatibility";
-            this.CHK_NoTutor.UseVisualStyleBackColor = true;
             // 
             // PersonalEditor7
             // 
@@ -1747,7 +1753,6 @@
         private System.Windows.Forms.TextBox TB_Stage;
         private System.Windows.Forms.Label L_Stage;
         private System.Windows.Forms.MaskedTextBox TB_CatchRate;
-        private System.Windows.Forms.TextBox TB_RawColor;
         private System.Windows.Forms.Label L_BST;
 		private System.Windows.Forms.TextBox TB_BST;
         private System.Windows.Forms.CheckedListBox CLB_TM;
@@ -1764,7 +1769,6 @@
         private System.Windows.Forms.Label L_StatDev;
         private System.Windows.Forms.CheckBox CHK_Item;
         private System.Windows.Forms.CheckBox CHK_Type;
-        private System.Windows.Forms.CheckBox CHK_HM;
         private System.Windows.Forms.CheckBox CHK_Tutors;
         private System.Windows.Forms.CheckBox CHK_WGuard;
         private System.Windows.Forms.CheckBox CHK_CatchRate;
@@ -1807,13 +1811,16 @@
         private System.Windows.Forms.ComboBox CB_ZMove;
         private System.Windows.Forms.ComboBox CB_ZBaseMove;
         private System.Windows.Forms.ComboBox CB_ZItem;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label L_ZMove;
         private System.Windows.Forms.Label L_BaseMove;
-        private System.Windows.Forms.Label L_ZItem;
+        private System.Windows.Forms.Label L_ZCrystal;
         private System.Windows.Forms.Label L_BeachTutors;
         private System.Windows.Forms.CheckedListBox CLB_BeachTutors;
         private System.Windows.Forms.CheckBox CHK_BeachTutors;
         private System.Windows.Forms.CheckBox CHK_Shuffle;
         private System.Windows.Forms.CheckBox CHK_NoTutor;
+        private System.Windows.Forms.Label L_HiddenAbility;
+        private System.Windows.Forms.Label L_Ability2;
+        private System.Windows.Forms.Label L_Ability1;
     }
 }

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.Designer.cs
@@ -159,6 +159,7 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
+            this.TB_RawColor = new System.Windows.Forms.TextBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -209,6 +210,7 @@
             // 
             // TP_General
             // 
+            this.TP_General.Controls.Add(this.TB_RawColor);
             this.TP_General.Controls.Add(this.L_HiddenAbility);
             this.TP_General.Controls.Add(this.L_WeightKG);
             this.TP_General.Controls.Add(this.L_Ability2);
@@ -1650,6 +1652,16 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
+            // TB_RawColor
+            // 
+            this.TB_RawColor.Location = new System.Drawing.Point(229, 209);
+            this.TB_RawColor.Name = "TB_RawColor";
+            this.TB_RawColor.ReadOnly = true;
+            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
+            this.TB_RawColor.TabIndex = 420;
+            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.TB_RawColor.Visible = false;
+            // 
             // PersonalEditor7
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1822,5 +1834,6 @@
         private System.Windows.Forms.Label L_HiddenAbility;
         private System.Windows.Forms.Label L_Ability2;
         private System.Windows.Forms.Label L_Ability1;
+        private System.Windows.Forms.TextBox TB_RawColor;
     }
 }

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.cs
@@ -194,7 +194,8 @@ namespace pk3DS
 
             TB_FormeCount.Text = pkm.FormeCount.ToString("000");
             TB_FormeSprite.Text = pkm.FormeSprite.ToString("000");
-            
+
+            TB_RawColor.Text = pkm.Color.ToString("000");
             CB_Color.SelectedIndex = pkm.Color & 0xF;
 
             TB_BaseExp.Text = pkm.BaseEXP.ToString("000");
@@ -280,7 +281,7 @@ namespace pk3DS
 
             pkm.FormeSprite = Convert.ToUInt16(TB_FormeSprite.Text);
             pkm.FormeCount = Convert.ToByte(TB_FormeCount.Text);
-            pkm.Color = (Convert.ToByte(CB_Color.SelectedIndex));
+            pkm.Color = (byte)(Convert.ToByte(CB_Color.SelectedIndex) | (Convert.ToByte(TB_RawColor.Text) & 0xF0));
             pkm.BaseEXP = Convert.ToUInt16(TB_BaseExp.Text);
 
             decimal h; decimal.TryParse(TB_Height.Text, out h);

--- a/pk3DS/Subforms/Gen7/PersonalEditor7.cs
+++ b/pk3DS/Subforms/Gen7/PersonalEditor7.cs
@@ -194,8 +194,7 @@ namespace pk3DS
 
             TB_FormeCount.Text = pkm.FormeCount.ToString("000");
             TB_FormeSprite.Text = pkm.FormeSprite.ToString("000");
-
-            TB_RawColor.Text = pkm.Color.ToString("000");
+            
             CB_Color.SelectedIndex = pkm.Color & 0xF;
 
             TB_BaseExp.Text = pkm.BaseEXP.ToString("000");
@@ -281,7 +280,7 @@ namespace pk3DS
 
             pkm.FormeSprite = Convert.ToUInt16(TB_FormeSprite.Text);
             pkm.FormeCount = Convert.ToByte(TB_FormeCount.Text);
-            pkm.Color = (byte) (Convert.ToByte(CB_Color.SelectedIndex) | (Convert.ToByte(TB_RawColor.Text) & 0xF0));
+            pkm.Color = (Convert.ToByte(CB_Color.SelectedIndex));
             pkm.BaseEXP = Convert.ToUInt16(TB_BaseExp.Text);
 
             decimal h; decimal.TryParse(TB_Height.Text, out h);
@@ -321,6 +320,7 @@ namespace pk3DS
 
         private void B_Randomize_Click(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Randomize all? Cannot undo.", "Double check Randomization settings in the Enhancements tab.") != DialogResult.Yes) return;
             saveEntry();
             
             // input settings
@@ -334,7 +334,7 @@ namespace pk3DS
                 StatsToRandomize = rstat_boxes.Select(g => g.Checked).ToArray(),
                 ModifyAbilities = CHK_Ability.Checked,
                 ModifyLearnsetTM = CHK_TM.Checked,
-                ModifyLearnsetHM = CHK_HM.Checked,
+                ModifyLearnsetHM = false, // no HMs in Gen 7
                 ModifyLearnsetTypeTutors = CHK_Tutors.Checked,
                 ModifyLearnsetMoveTutors = Main.Config.USUM && CHK_BeachTutors.Checked,
                 ModifyTypes = CHK_Type.Checked,
@@ -348,10 +348,12 @@ namespace pk3DS
             Main.SpeciesStat.Select(z => z.Write()).ToArray().CopyTo(files, 0);
 
             readEntry();
-            WinFormsUtil.Alert("All relevant Pokémon Personal Entries have been randomized!");
+            WinFormsUtil.Alert("Randomized all Pokémon Personal data entries according to specification!", "Press the Dump All button to view the new Personal data!");
         }
         private void B_ModifyAll(object sender, EventArgs e)
         {
+            if (WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Modify all? Cannot undo.", "Double check Modification settings in the Enhancements tab.") != DialogResult.Yes) return;
+
             for (int i = 1; i < CB_Species.Items.Count; i++)
             {
                 CB_Species.SelectedIndex = i; // Get new Species
@@ -378,11 +380,11 @@ namespace pk3DS
                     TB_HatchCycles.Text = 1.ToString();
                 if (CHK_CallRate.Checked)
                     TB_CallRate.Text = ((int)NUD_CallRate.Value).ToString();
-                if(CHK_CatchRateMod.Checked)
+                if (CHK_CatchRateMod.Checked)
                     TB_CatchRate.Text = ((int)NUD_CatchRateMod.Value).ToString();
             }
             CB_Species.SelectedIndex = 1;
-            WinFormsUtil.Alert("All species modified according to specification!");
+            WinFormsUtil.Alert("Modified all Pokémon Personal data entries according to specification!", "Press the Dump All button to view the new Personal data!");
         }
         private bool dumping;
         private void B_Dump_Click(object sender, EventArgs e)

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -736,7 +736,7 @@ namespace pk3DS
                     }
 
                     // high-power attacks
-                    if (CHK_ForceHighPower.Checked && pk.Level >= NUD_ForceHighPower.Value && CB_Moves.SelectedIndex != 3)
+                    if (CHK_ForceHighPower.Checked && pk.Level >= NUD_ForceHighPower.Value)
                         pk.Moves = learn.GetHighPoweredMoves(pk.Species, pk.Form, 4);
 
                     // sanitize moves
@@ -779,7 +779,12 @@ namespace pk3DS
         // Randomization UI
         private void CB_Moves_SelectedIndexChanged(object sender, EventArgs e)
         {
-            CHK_Damage.Visible = CHK_STAB.Visible = NUD_Damage.Visible = NUD_STAB.Visible = CB_Moves.SelectedIndex == 1; // Randomized
+            CHK_Damage.Checked = CHK_STAB.Checked =
+            CHK_Damage.Enabled = CHK_STAB.Enabled =
+            NUD_Damage.Enabled = NUD_STAB.Enabled = CB_Moves.SelectedIndex == 1;
+
+            CHK_ForceHighPower.Enabled = CHK_ForceHighPower.Checked = NUD_ForceHighPower.Enabled =
+            CHK_NoFixedDamage.Enabled = CHK_NoFixedDamage.Checked = (CB_Moves.SelectedIndex == 1 || CB_Moves.SelectedIndex == 2);
         }
         private void CHK_Damage_CheckedChanged(object sender, EventArgs e)
         {
@@ -791,14 +796,18 @@ namespace pk3DS
         }
         private void CHK_RandomPKM_CheckedChanged(object sender, EventArgs e)
         {
-            CHK_BST.Visible = CHK_RandomPKM.Checked;
-            if (CHK_RandomPKM.Checked)
-                return;
-            foreach (CheckBox c in new[] { CHK_G1, CHK_G2, CHK_G3, CHK_G4, CHK_G5, CHK_G6, CHK_G7, CHK_L, CHK_E })
-            {
-                c.Visible = false;
-                c.Checked = true;
-            }
+            if (!CHK_RandomPKM.Checked)
+                foreach (CheckBox c in new[] { CHK_G1, CHK_G2, CHK_G3, CHK_G4, CHK_G5, CHK_G6, CHK_G7, CHK_L, CHK_E, CHK_BST })
+                {
+                    c.Enabled = false;
+                    c.Checked = false;
+                }
+            else
+                foreach (CheckBox c in new[] { CHK_G1, CHK_G2, CHK_G3, CHK_G4, CHK_G5, CHK_G6, CHK_G7, CHK_L, CHK_E, CHK_BST })
+                {
+                    c.Enabled = true;
+                    c.Checked = true;
+                }
         }
         private void CHK_RandomClass_CheckedChanged(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -465,7 +465,7 @@ namespace pk3DS
             var specrand = getRandomizer();
             var formrand = new FormRandomizer(Main.Config) { AllowMega = false, AllowAlolanForm = true };
             var items = Randomizer.getRandomItemList();
-            int[] banned = Legal.Z_Moves.Concat(new int[] {165, 464, 621}).ToArray();
+            int[] banned = Legal.Z_Moves.Concat(new int[] { 165, 464, 621 }).ToArray();
 
             // Assign Species
             for (int i = 0; i < 3; i++)
@@ -496,8 +496,9 @@ namespace pk3DS
 
                 if (CHK_SpecialMove.Checked && !CHK_Metronome.Checked)
                 {
-                    int rv = Util.rand.Next(1, CB_SpecialMove.Items.Count);
-                    if (banned.Contains(rv)) continue; // disallow banned moves
+                    int rv;
+                    do { rv = Util.rand.Next(1, CB_SpecialMove.Items.Count); }
+                    while (banned.Contains(rv)) ;
                     t.SpecialMove = rv;
                 }
 
@@ -526,7 +527,7 @@ namespace pk3DS
             var formrand = new FormRandomizer(Main.Config) { AllowMega = false, AllowAlolanForm = true };
             var move = new LearnsetRandomizer(Main.Config, Main.Config.Learnsets);
             var items = Randomizer.getRandomItemList();
-            int[] banned = Legal.Z_Moves.Concat(new int[] { 165, 621 }).ToArray();
+            int[] banned = Legal.Z_Moves.Concat(new int[] { 165, 464, 621 }).ToArray();
             int randFinalEvo() => (int)(Util.rnd32() % FinalEvo.Length);
             int randLegend() => (int)(Util.rnd32() % ReplaceLegend.Length);
 
@@ -560,8 +561,9 @@ namespace pk3DS
                         t.SpecialMove = 0; // remove Surf Pikachu's special move
                     else
                     {
-                        int rv = Util.rand.Next(1, CB_SpecialMove.Items.Count);
-                        if (banned.Contains(rv)) continue; // disallow banned moves
+                        int rv;
+                        do { rv = Util.rand.Next(1, CB_SpecialMove.Items.Count); }
+                        while (banned.Contains(rv));
                         t.SpecialMove = rv;
                     }
                 }


### PR DESCRIPTION
- Add/revise prompts before and after randomizing
  • Personal Editors (Randomize/Modify)
  • Egg Move Editors
- Remove redundant form set for GiftEditor6
- Redesign PersonalEditor6's GUI to match PersonalEditor7
  • Group several combo boxes together
  • Add labels that denote Ability 1, 2, and H
  • Change Z-Move based labels (based on several in-game tests, the game *only*  allows Z-Crystals for modified Z-Moves...)
  • Remove HM Compatibility references in PersonalEditor7
- Redesign RSTE to expand several combo boxes to fit text
- Add prompt before opening OWSE
- Revise some Button labels in `Main.cs`
- Rework several `CheckedChanged` methods
  • SMTE will no longer permanently hide Gen 1-7 and BST Checkboxes if `CHK_RandomPKM` is unchecked
  • Force High-Powered Attacks will be disabled if `CB_Moves` is set to "Do Not Modify" or "Metronome Mode"
  • No Fixed Damage Moves will only be enabled if `CB_Moves` is set to "Randomize All" or "Use Levelup Only"
  • Force Fully Evolved will be disabled if "Random Pokémon" is unchecked
- Fix a bug which would, on rare occurrences, allow (None) to be set to a Gift Move when randomizing

New PersonalEditor7:
![image](https://user-images.githubusercontent.com/17801814/38580011-cf357c68-3cd6-11e8-94c0-d2020b9b259d.png)

New RSTE (Trainer Class name now properly fits the combo box, like SMTE's does):
![image](https://user-images.githubusercontent.com/17801814/38580061-f8c7dcc4-3cd6-11e8-8a9f-01137cf8c5a9.png)