### PR TITLE
Add full HM compatiblity mod

### DIFF
--- a/pk3DS/Subforms/Gen6/GiftEditor6.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.cs
@@ -267,6 +267,7 @@ namespace pk3DS
                 NUD_Form.Value = formrand.GetRandomForme(species);
                 CB_Gender.SelectedIndex = 0; // random
                 CB_Nature.SelectedIndex = 0; // random
+                NUD_IV0.Value = NUD_IV1.Value = NUD_IV2.Value = NUD_IV3.Value = NUD_IV4.Value = NUD_IV5.Value = -1; // random
 
                 if (MegaDictionary.Values.Any(z => z.Contains(CB_HeldItem.SelectedIndex)) && NUD_Form.Value != 0)
                     NUD_Form.Value = 0; // don't allow mega gifts to be form 1

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.Designer.cs
@@ -32,6 +32,7 @@
             this.L_Species_Precursor = new System.Windows.Forms.Label();
             this.TC_Pokemon = new System.Windows.Forms.TabControl();
             this.TP_General = new System.Windows.Forms.TabPage();
+            this.TB_RawColor = new System.Windows.Forms.TextBox();
             this.L_HiddenAbility = new System.Windows.Forms.Label();
             this.L_Ability2 = new System.Windows.Forms.Label();
             this.L_Ability1 = new System.Windows.Forms.Label();
@@ -148,7 +149,7 @@
             this.B_Randomize = new System.Windows.Forms.Button();
             this.PB_MonSprite = new System.Windows.Forms.PictureBox();
             this.B_Dump = new System.Windows.Forms.Button();
-            this.TB_RawColor = new System.Windows.Forms.TextBox();
+            this.CHK_FullHMCompatibility = new System.Windows.Forms.CheckBox();
             this.TC_Pokemon.SuspendLayout();
             this.TP_General.SuspendLayout();
             this.TP_MoveTutors.SuspendLayout();
@@ -274,6 +275,16 @@
             this.TP_General.TabIndex = 0;
             this.TP_General.Text = "General Info";
             this.TP_General.UseVisualStyleBackColor = true;
+            // 
+            // TB_RawColor
+            // 
+            this.TB_RawColor.Location = new System.Drawing.Point(229, 209);
+            this.TB_RawColor.Name = "TB_RawColor";
+            this.TB_RawColor.ReadOnly = true;
+            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
+            this.TB_RawColor.TabIndex = 419;
+            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.TB_RawColor.Visible = false;
             // 
             // L_HiddenAbility
             // 
@@ -1037,6 +1048,7 @@
             // 
             // GB_Modifier
             // 
+            this.GB_Modifier.Controls.Add(this.CHK_FullHMCompatibility);
             this.GB_Modifier.Controls.Add(this.CHK_NoTutor);
             this.GB_Modifier.Controls.Add(this.CHK_CatchRateMod);
             this.GB_Modifier.Controls.Add(this.L_CatchRateMod);
@@ -1049,7 +1061,7 @@
             this.GB_Modifier.Controls.Add(this.CHK_NoEV);
             this.GB_Modifier.Location = new System.Drawing.Point(4, 147);
             this.GB_Modifier.Name = "GB_Modifier";
-            this.GB_Modifier.Size = new System.Drawing.Size(345, 129);
+            this.GB_Modifier.Size = new System.Drawing.Size(345, 152);
             this.GB_Modifier.TabIndex = 419;
             this.GB_Modifier.TabStop = false;
             this.GB_Modifier.Text = "Modifier Options";
@@ -1523,15 +1535,15 @@
             this.B_Dump.UseVisualStyleBackColor = true;
             this.B_Dump.Click += new System.EventHandler(this.B_Dump_Click);
             // 
-            // TB_RawColor
+            // CHK_FullHMCompatibility
             // 
-            this.TB_RawColor.Location = new System.Drawing.Point(229, 209);
-            this.TB_RawColor.Name = "TB_RawColor";
-            this.TB_RawColor.ReadOnly = true;
-            this.TB_RawColor.Size = new System.Drawing.Size(30, 20);
-            this.TB_RawColor.TabIndex = 419;
-            this.TB_RawColor.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.TB_RawColor.Visible = false;
+            this.CHK_FullHMCompatibility.AutoSize = true;
+            this.CHK_FullHMCompatibility.Location = new System.Drawing.Point(6, 127);
+            this.CHK_FullHMCompatibility.Name = "CHK_FullHMCompatibility";
+            this.CHK_FullHMCompatibility.Size = new System.Drawing.Size(123, 17);
+            this.CHK_FullHMCompatibility.TabIndex = 21;
+            this.CHK_FullHMCompatibility.Text = "Full HM Compatibility";
+            this.CHK_FullHMCompatibility.UseVisualStyleBackColor = true;
             // 
             // PersonalEditor6
             // 
@@ -1694,5 +1706,6 @@
         private System.Windows.Forms.Label L_Ability2;
         private System.Windows.Forms.Label L_Ability1;
         private System.Windows.Forms.TextBox TB_RawColor;
+        private System.Windows.Forms.CheckBox CHK_FullHMCompatibility;
     }
 }

--- a/pk3DS/Subforms/Gen6/PersonalEditor6.cs
+++ b/pk3DS/Subforms/Gen6/PersonalEditor6.cs
@@ -400,6 +400,10 @@ namespace pk3DS
                         CLB_ORASTutors.SetItemCheckState(ao, CheckState.Unchecked);
                 }
 
+                if (CHK_FullHMCompatibility.Checked)
+                    for (int h = 100; h < CLB_TMHM.Items.Count; h++)
+                        CLB_TMHM.SetItemCheckState(h, CheckState.Checked);
+
                 if (CHK_QuickHatch.Checked)
                     TB_HatchCycles.Text = 1.ToString();
                 if (CHK_CatchRateMod.Checked)

--- a/pk3DS/Subforms/Gen7/MartEditor7UU.cs
+++ b/pk3DS/Subforms/Gen7/MartEditor7UU.cs
@@ -103,7 +103,6 @@ namespace pk3DS
 
         private int entryItem = -1;
         private int entryBPItem = -1;
-        private int entryBPMove = -1;
 
         private void changeIndexItem(object sender, EventArgs e)
         {

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -666,6 +666,13 @@ namespace pk3DS
                 if (CHK_ForceFullyEvolved.Checked && t.Level >= NUD_ForceFullyEvolved.Value && !FinalEvo.Contains(t.Species))
                     t.Species = FinalEvo[randFinalEvo()];
 
+                if (t.IV3)
+                    t.IVs = new[] { -4, -1, -1, -1, -1, -1 }; // random with IV3 flag
+                else
+                    t.IVs = new[] { -1, -1, -1, -1, -1, -1 }; // random
+
+                t.EVs = new[] { 0, 0, 0, 0, 0, 0 }; // reset EVs
+
                 t.Form = Randomizer.GetRandomForme(t.Species, CHK_AllowMega.Checked, true, Main.SpeciesStat);
                 t.Gender = 0; // random
                 t.Nature = 0; // random
@@ -697,6 +704,7 @@ namespace pk3DS
 
                 t.Form = Randomizer.GetRandomForme(t.Species, CHK_AllowMega.Checked, true, Main.SpeciesStat);
                 t.Nature = (int)(Util.rnd32() % CB_TNature.Items.Count); // randomly selected
+                t.IVs = new[] { -1, -1, -1, -1, -1, -1 }; // random
             }
 
             GetListBoxEntries();


### PR DESCRIPTION
Also add code to set Gen 6 gift and Gen 7 static/trade encounters to have random IVs rather than pre-set, in addition to resetting EVs for Gen 7 encounters (EV spreads were designed for specific fights making them bizarre for randomized Pokemon).