### PR TITLE
Misc updates

### DIFF
--- a/pk3DS.Core/Legality/Legal.cs
+++ b/pk3DS.Core/Legality/Legal.cs
@@ -383,55 +383,134 @@ namespace pk3DS.Core
         {
             722, 725, 728, 731, 736, 761, 782, 789
         }).ToArray();
-
-        /// <summary>
-        /// All final evolutions, excluding Event-exclusive Forms that do not evolve (Pikachu, Floette, etc). Used for forcing fully evolved species.
-        /// Overrides all other randomizer settings, allowing all Generations and Legendary/Mythical Pokemon as well.
-        /// </summary>
+        
         public static readonly int[] FinalEvolutions_6 =
         {
             003, 006, 009, 012, 015, 018, 020, 022, 024, 026, 028, 031, 034, 036, 038, 040, 045, 047, 049, 051, 053, 055, 057, 059, 062, 065, 068, 071, 073, 076, 078, 080, 083, 085, 087, 089, 091,
-            094, 097, 099, 101, 103, 105, 106, 107, 110, 115, 119, 121, 122, 124, 127, 128, 130, 131, 132, 134, 135, 136, 139, 141, 142, 143, 144, 145, 146, 149, 150, 151, 154, 157, 160, 162, 164,
-            166, 168, 169, 171, 178, 181, 182, 184, 185, 186, 189, 192, 195, 196, 197, 199, 201, 202, 203, 205, 206, 208, 210, 211, 212, 213, 214, 217, 219, 222, 224, 225, 226, 227, 229, 230, 232,
-            234, 235, 237, 241, 242, 243, 244, 245, 248, 249, 250, 251, 254, 257, 260, 262, 264, 267, 269, 272, 275, 277, 279, 282, 284, 286, 289, 291, 292, 295, 297, 301, 302, 303, 306, 308, 310,
-            311, 312, 313, 314, 317, 319, 321, 323, 324, 326, 327, 330, 332, 334, 335, 336, 337, 338, 340, 342, 344, 346, 348, 350, 351, 352, 354, 357, 358, 359, 362, 365, 367, 368, 369, 370, 373,
-            376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 389, 392, 395, 398, 400, 402, 405, 407, 409, 411, 413, 414, 416, 417, 419, 421, 423, 424, 426, 428, 429, 430, 432, 435, 437, 441,
-            442, 445, 448, 450, 452, 454, 455, 457, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488,
-            489, 490, 491, 492, 493, 494, 497, 500, 503, 505, 508, 510, 512, 514, 516, 518, 521, 523, 526, 528, 530, 531, 534, 537, 538, 539, 542, 545, 547, 549, 550, 553, 555, 556, 558, 560, 561,
-            563, 565, 567, 569, 571, 573, 576, 579, 581, 584, 586, 587, 589, 591, 593, 594, 596, 598, 601, 604, 606, 609, 612, 614, 615, 617, 618, 620, 621, 623, 625, 626, 628, 630, 631, 632, 635,
-            637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 652, 655, 658, 660, 663, 666, 668, 671, 673, 675, 676, 678, 681, 683, 685, 687, 689, 691, 693, 695, 697, 699, 700, 701,
-            702, 703, 706, 707, 709, 711, 713, 715, 716, 717, 718, 719, 720, 721
+            094, 097, 099, 101, 103, 105, 106, 107, 110, 115, 119, 121, 122, 124, 127, 128, 130, 131, 132, 134, 135, 136, 139, 141, 142, 143, 149, 154, 157, 160, 162, 164, 166, 168, 169, 171, 178,
+            181, 182, 184, 185, 186, 189, 192, 195, 196, 197, 199, 201, 202, 203, 205, 206, 208, 210, 211, 212, 213, 214, 217, 219, 222, 224, 225, 226, 227, 229, 230, 232, 234, 235, 237, 241, 242,
+            248, 254, 257, 260, 262, 264, 267, 269, 272, 275, 277, 279, 282, 284, 286, 289, 291, 292, 295, 297, 301, 302, 303, 306, 308, 310, 311, 312, 313, 314, 317, 319, 321, 323, 324, 326, 327,
+            330, 332, 334, 335, 336, 337, 338, 340, 342, 344, 346, 348, 350, 351, 352, 354, 357, 358, 359, 362, 365, 367, 368, 369, 370, 373, 376, 389, 392, 395, 398, 400, 402, 405, 407, 409, 411,
+            413, 414, 416, 417, 419, 421, 423, 424, 426, 428, 429, 430, 432, 435, 437, 441, 442, 445, 448, 450, 452, 454, 455, 457, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472,
+            473, 474, 475, 476, 477, 478, 479, 497, 500, 503, 505, 508, 510, 512, 514, 516, 518, 521, 523, 526, 528, 530, 531, 534, 537, 538, 539, 542, 545, 547, 549, 550, 553, 555, 556, 558, 560,
+            561, 563, 565, 567, 569, 571, 573, 576, 579, 581, 584, 586, 587, 589, 591, 593, 594, 596, 598, 601, 604, 606, 609, 612, 614, 615, 617, 618, 620, 621, 623, 625, 626, 628, 630, 631, 632,
+            635, 637, 652, 655, 658, 660, 663, 666, 668, 671, 673, 675, 676, 678, 681, 683, 685, 687, 689, 691, 693, 695, 697, 699, 700, 701, 702, 703, 706, 707, 709, 711, 713, 715,
+        };
+        
+        public static readonly int[] FinalEvolutions_7 = FinalEvolutions_6.Concat(new int[]
+        {
+            724, 727, 730, 733, 735, 738, 740, 741, 743, 745, 746, 748, 750, 752, 754, 756, 758, 760, 763, 764, 765, 766, 768, 770, 771, 774, 775, 776, 777, 779, 780, 781, 784,
+        }).ToArray();
+        
+        public static readonly int[] Legendary_6 =
+        {
+            #region Legendary
+            144, // Articuno
+            145, // Zapdos
+            146, // Moltres
+            150, // Mewtwo
+            243, // Raikou
+            244, // Entei
+            245, // Suicune
+            249, // Lugia
+            250, // Ho-Oh
+            377, // Regirock
+            378, // Regice
+            379, // Registeel
+            380, // Latias
+            381, // Latios
+            382, // Kyogre
+            383, // Groudon
+            384, // Rayquaza
+            480, // Uxie
+            481, // Mesprit
+            482, // Azelf
+            483, // Dialga
+            484, // Palkia
+            485, // Heatran
+            486, // Regigigas
+            487, // Giratina
+            488, // Cresselia
+            638, // Cobalion
+            639, // Terrakion
+            640, // Virizion
+            641, // Tornadus
+            642, // Thundurus
+            643, // Reshiram
+            644, // Zekrom
+            645, // Landorus
+            646, // Kyurem
+            716, // Xerneas
+            717, // Yveltal
+            718, // Zygarde
+            #endregion
         };
 
-        public static readonly int[] FinalEvolutions_SM = FinalEvolutions_6.Concat(new int[]
+        public static readonly int[] Legendary_SM = Legendary_6.Concat(new int[]
         {
-            724, 727, 730, 733, 735, 738, 740, 741, 743, 745, 746, 748, 750, 752, 754, 756, 758, 760, 763, 764, 765, 766, 768, 770, 771, 773, 774, 775, 776, 777, 779, 780, 781, 784, 785, 786, 787,
-            788, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802
+            #region Legendary
+            773, // Silvally
+            785, // Tapu Koko
+            786, // Tapu Lele
+            787, // Tapu Bulu
+            788, // Tapu Fini
+            791, // Solgaleo
+            792, // Lunala
+            793, // Nihilego
+            794, // Buzzwole
+            795, // Pheromosa
+            796, // Xurkitree
+            797, // Celesteela
+            798, // Kartana
+            799, // Guzzlord
+            800, // Necrozma
+            #endregion
         }).ToArray();
 
-        public static readonly int[] FinalEvolutions_USUM = FinalEvolutions_SM.Concat(new int[]
+        public static readonly int[] Legendary_USUM = Legendary_SM.Concat(new int[]
         {
-            804, 805, 806, 807
+            #region Legendary
+            804, // Naganadel
+            805, // Stakataka
+            806, // Blacephalon
+            #endregion
         }).ToArray();
 
-        /// <summary>
-        /// All Legendary and Mythical Pokemon. Used for Legendary-for-Legendary replacement.
-        /// Does not include un-evolved species in the array due to potential error with Force Fully Evolved.
-        /// </summary>
-        public static readonly int[] Legendary_Mythical_6 =
+        public static readonly int[] Mythical_6 =
         {
-            144, 145, 146, 150, 151, 243, 244, 245, 249, 250, 251, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 638,
-            639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 716, 717, 718, 719, 720, 721
+            #region Mythical
+            151, // Mew
+            251, // Celebi
+            385, // Jirachi
+            386, // Deoxys
+            489, // Phione
+            490, // Manaphy
+            491, // Darkrai
+            492, // Shaymin
+            493, // Arceus
+            494, // Victini
+            647, // Keldeo
+            648, // Meloetta
+            649, // Genesect
+            719, // Diancie
+            720, // Hoopa
+            721, // Volcanion
+            #endregion
         };
 
-        public static readonly int[] Legendary_Mythical_SM = Legendary_Mythical_6.Concat(new int[]
+        public static readonly int[] Mythical_SM = Mythical_6.Concat(new int[]
         {
-            773, 785, 786, 787, 788, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802
+            #region Mythical
+            801, // Magearna
+            802, // Marshadow
+            #endregion
         }).ToArray();
 
-        public static readonly int[] Legendary_Mythical_USUM = Legendary_Mythical_SM.Concat(new int[]
+        public static readonly int[] Mythical_USUM = Mythical_SM.Concat(new int[]
         {
-            804, 805, 806, 807
+            #region Mythical
+            807, // Zeraora
+            #endregion
         }).ToArray();
 
         public static readonly HashSet<int> BattleForms = new HashSet<int>

--- a/pk3DS/Subforms/Gen6/GiftEditor6.cs
+++ b/pk3DS/Subforms/Gen6/GiftEditor6.cs
@@ -59,7 +59,9 @@ namespace pk3DS
         private readonly string[] specieslist = Main.Config.getText(TextName.SpeciesNames);
         private readonly string[] natureslist = Main.Config.getText(TextName.Natures);
         private readonly Dictionary<int, int[]> MegaDictionary;
-        private static int[] FinalEvo;
+        private static int[] FinalEvo = Legal.FinalEvolutions_6;
+        private static int[] Legendary = Legal.Legendary_6;
+        private static int[] Mythical = Legal.Mythical_6;
         
         private readonly string[] ability =
         {
@@ -98,8 +100,6 @@ namespace pk3DS
             CB_Gender.Items.Add("- / Genderless/Random");
             CB_Gender.Items.Add("♂ / Male");
             CB_Gender.Items.Add("♀ / Female");
-
-            FinalEvo = Legal.FinalEvolutions_6;
 
             loaded = true;
             LB_Gifts.SelectedIndex = 0;
@@ -224,6 +224,11 @@ namespace pk3DS
                 rBST = CHK_BST.Checked,
             };
             specrand.Initialize();
+
+            // add Legendary/Mythical to final evolutions if checked
+            if (CHK_L.Checked) FinalEvo = FinalEvo.Concat(Legendary).ToArray();
+            if (CHK_E.Checked) FinalEvo = FinalEvo.Concat(Mythical).ToArray();
+
             var helditems = Randomizer.getRandomItemList();
             for (int i = 0; i < LB_Gifts.Items.Count; i++)
             {

--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -452,7 +452,7 @@ namespace pk3DS
         public static int rDMGCount, rSTABCount;
         private int[] mEvoTypes;
         private static int[] rModelRestricted;
-        private static int[] rFinalEvo;
+        public static int[] rFinalEvo;
         private string[] rImportant;
         private readonly List<string> Tags = new List<string>();
         private readonly Dictionary<string, int> TagTypes = new Dictionary<string, int>();

--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
@@ -43,8 +43,10 @@ namespace pk3DS
         private EncounterStatic6[] EncounterData;
         private readonly string[] itemlist = Main.Config.getText(TextName.ItemNames);
         private readonly string[] specieslist = Main.Config.getText(TextName.SpeciesNames);
-        private static int[] FinalEvo;
-        private static int[] ReplaceLegend;
+        private static int[] FinalEvo = Legal.FinalEvolutions_6;
+        private static int[] Legendary = Legal.Legendary_6;
+        private static int[] Mythical = Legal.Mythical_6;
+        private static int[] ReplaceLegend = Legendary.Concat(Mythical).ToArray();
 
         private readonly string[] ability =
         {
@@ -83,9 +85,6 @@ namespace pk3DS
             CB_Gender.Items.Add("- / Genderless/Random");
             CB_Gender.Items.Add("♂ / Male");
             CB_Gender.Items.Add("♀ / Female");
-
-            FinalEvo = Legal.FinalEvolutions_6;
-            ReplaceLegend = Legal.Legendary_Mythical_6;
 
             loaded = true;
             LB_Encounters.SelectedIndex = 0;
@@ -170,6 +169,11 @@ namespace pk3DS
                 rBST = CHK_BST.Checked,
             };
             specrand.Initialize();
+
+            // add Legendary/Mythical to final evolutions if checked
+            if (CHK_L.Checked) FinalEvo = FinalEvo.Concat(Legendary).ToArray();
+            if (CHK_E.Checked) FinalEvo = FinalEvo.Concat(Mythical).ToArray();
+
             var items = Randomizer.getRandomItemList();
             for (int i = 0; i < LB_Encounters.Items.Count; i++)
             {

--- a/pk3DS/Subforms/Gen6/TrainerRand.cs
+++ b/pk3DS/Subforms/Gen6/TrainerRand.cs
@@ -23,6 +23,8 @@ namespace pk3DS
         private readonly string[] trName = Main.Config.getText(TextName.TrainerNames);
         private readonly string[] trClass = Main.Config.getText(TextName.TrainerClasses);
         private readonly List<string> trClassnorep;
+        private static int[] Legendary = Legal.Legendary_6;
+        private static int[] Mythical = Legal.Mythical_6;
 
         private void B_Close_Click(object sender, EventArgs e)
         {
@@ -110,6 +112,10 @@ namespace pk3DS
                 rEXP = false,
             };
             RSTE.rSpeciesRand.Initialize();
+
+            // add Legendary/Mythical to final evolutions if checked
+            if (CHK_L.Checked) RSTE.rFinalEvo = RSTE.rFinalEvo.Concat(Legendary).ToArray();
+            if (CHK_E.Checked) RSTE.rFinalEvo = RSTE.rFinalEvo.Concat(Mythical).ToArray();
 
             RSTE.rDoRand = true;
             RandSettings.SetFormSettings(this, Controls);

--- a/pk3DS/Subforms/Gen7/SMTE.Designer.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.Designer.cs
@@ -179,7 +179,6 @@
             this.CHK_STAB = new System.Windows.Forms.CheckBox();
             this.Tab_Trainer1 = new System.Windows.Forms.TabPage();
             this.CHK_ReplaceMega = new System.Windows.Forms.CheckBox();
-            this.CHK_ReplaceLegend = new System.Windows.Forms.CheckBox();
             this.CHK_6PKM = new System.Windows.Forms.CheckBox();
             this.NUD_ForceFullyEvolved = new System.Windows.Forms.NumericUpDown();
             this.L_MinPKM = new System.Windows.Forms.Label();
@@ -1977,7 +1976,6 @@
             // Tab_Trainer1
             // 
             this.Tab_Trainer1.Controls.Add(this.CHK_ReplaceMega);
-            this.Tab_Trainer1.Controls.Add(this.CHK_ReplaceLegend);
             this.Tab_Trainer1.Controls.Add(this.CHK_6PKM);
             this.Tab_Trainer1.Controls.Add(this.NUD_ForceFullyEvolved);
             this.Tab_Trainer1.Controls.Add(this.L_MinPKM);
@@ -2002,31 +2000,18 @@
             this.CHK_ReplaceMega.AutoSize = true;
             this.CHK_ReplaceMega.Checked = true;
             this.CHK_ReplaceMega.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_ReplaceMega.Location = new System.Drawing.Point(6, 121);
+            this.CHK_ReplaceMega.Location = new System.Drawing.Point(6, 118);
             this.CHK_ReplaceMega.Name = "CHK_ReplaceMega";
             this.CHK_ReplaceMega.Size = new System.Drawing.Size(196, 17);
             this.CHK_ReplaceMega.TabIndex = 343;
             this.CHK_ReplaceMega.Text = "Ensure Post-Game Mega Evolutions";
             this.CHK_ReplaceMega.UseVisualStyleBackColor = true;
             // 
-            // CHK_ReplaceLegend
-            // 
-            this.CHK_ReplaceLegend.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.CHK_ReplaceLegend.AutoSize = true;
-            this.CHK_ReplaceLegend.Checked = true;
-            this.CHK_ReplaceLegend.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_ReplaceLegend.Location = new System.Drawing.Point(6, 44);
-            this.CHK_ReplaceLegend.Name = "CHK_ReplaceLegend";
-            this.CHK_ReplaceLegend.Size = new System.Drawing.Size(257, 17);
-            this.CHK_ReplaceLegend.TabIndex = 342;
-            this.CHK_ReplaceLegend.Text = "Team Rainbow Rocket Legendary-for-Legendary";
-            this.CHK_ReplaceLegend.UseVisualStyleBackColor = true;
-            // 
             // CHK_6PKM
             // 
             this.CHK_6PKM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_6PKM.AutoSize = true;
-            this.CHK_6PKM.Location = new System.Drawing.Point(6, 107);
+            this.CHK_6PKM.Location = new System.Drawing.Point(6, 104);
             this.CHK_6PKM.Name = "CHK_6PKM";
             this.CHK_6PKM.Size = new System.Drawing.Size(183, 17);
             this.CHK_6PKM.TabIndex = 341;
@@ -2035,7 +2020,7 @@
             // 
             // NUD_ForceFullyEvolved
             // 
-            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(165, 77);
+            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(165, 74);
             this.NUD_ForceFullyEvolved.Minimum = new decimal(new int[] {
             1,
             0,
@@ -2052,7 +2037,7 @@
             // 
             // L_MinPKM
             // 
-            this.L_MinPKM.Location = new System.Drawing.Point(191, 0);
+            this.L_MinPKM.Location = new System.Drawing.Point(191, 3);
             this.L_MinPKM.Name = "L_MinPKM";
             this.L_MinPKM.Size = new System.Drawing.Size(60, 20);
             this.L_MinPKM.TabIndex = 338;
@@ -2061,7 +2046,7 @@
             // 
             // L_MaxPKM
             // 
-            this.L_MaxPKM.Location = new System.Drawing.Point(191, 21);
+            this.L_MaxPKM.Location = new System.Drawing.Point(191, 24);
             this.L_MaxPKM.Name = "L_MaxPKM";
             this.L_MaxPKM.Size = new System.Drawing.Size(60, 20);
             this.L_MaxPKM.TabIndex = 337;
@@ -2070,7 +2055,7 @@
             // 
             // NUD_RMin
             // 
-            this.NUD_RMin.Location = new System.Drawing.Point(257, 2);
+            this.NUD_RMin.Location = new System.Drawing.Point(257, 5);
             this.NUD_RMin.Maximum = new decimal(new int[] {
             6,
             0,
@@ -2092,7 +2077,7 @@
             // 
             // NUD_RMax
             // 
-            this.NUD_RMax.Location = new System.Drawing.Point(257, 23);
+            this.NUD_RMax.Location = new System.Drawing.Point(257, 26);
             this.NUD_RMax.Maximum = new decimal(new int[] {
             6,
             0,
@@ -2116,7 +2101,7 @@
             // 
             this.CHK_RandomMegaForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_RandomMegaForm.AutoSize = true;
-            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(6, 93);
+            this.CHK_RandomMegaForm.Location = new System.Drawing.Point(6, 90);
             this.CHK_RandomMegaForm.Name = "CHK_RandomMegaForm";
             this.CHK_RandomMegaForm.Size = new System.Drawing.Size(127, 17);
             this.CHK_RandomMegaForm.TabIndex = 333;
@@ -2129,7 +2114,7 @@
             this.CHK_TypeTheme.AutoSize = true;
             this.CHK_TypeTheme.Checked = true;
             this.CHK_TypeTheme.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_TypeTheme.Location = new System.Drawing.Point(6, 30);
+            this.CHK_TypeTheme.Location = new System.Drawing.Point(6, 33);
             this.CHK_TypeTheme.Name = "CHK_TypeTheme";
             this.CHK_TypeTheme.Size = new System.Drawing.Size(127, 17);
             this.CHK_TypeTheme.TabIndex = 329;
@@ -2142,7 +2127,7 @@
             this.CHK_IgnoreSpecialClass.AutoSize = true;
             this.CHK_IgnoreSpecialClass.Checked = true;
             this.CHK_IgnoreSpecialClass.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_IgnoreSpecialClass.Location = new System.Drawing.Point(6, 16);
+            this.CHK_IgnoreSpecialClass.Location = new System.Drawing.Point(6, 19);
             this.CHK_IgnoreSpecialClass.Name = "CHK_IgnoreSpecialClass";
             this.CHK_IgnoreSpecialClass.Size = new System.Drawing.Size(133, 17);
             this.CHK_IgnoreSpecialClass.TabIndex = 327;
@@ -2155,7 +2140,7 @@
             this.CHK_RandomClass.AutoSize = true;
             this.CHK_RandomClass.Checked = true;
             this.CHK_RandomClass.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RandomClass.Location = new System.Drawing.Point(6, 2);
+            this.CHK_RandomClass.Location = new System.Drawing.Point(6, 5);
             this.CHK_RandomClass.Name = "CHK_RandomClass";
             this.CHK_RandomClass.Size = new System.Drawing.Size(141, 17);
             this.CHK_RandomClass.TabIndex = 326;
@@ -2167,7 +2152,7 @@
             // 
             this.CHK_ForceFullyEvolved.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_ForceFullyEvolved.AutoSize = true;
-            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(6, 79);
+            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(6, 76);
             this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
             this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
             this.CHK_ForceFullyEvolved.TabIndex = 339;
@@ -2418,7 +2403,6 @@
         private System.Windows.Forms.CheckBox CHK_6PKM;
         private System.Windows.Forms.CheckBox CHK_ForceHighPower;
         private System.Windows.Forms.NumericUpDown NUD_ForceHighPower;
-        private System.Windows.Forms.CheckBox CHK_ReplaceLegend;
         private System.Windows.Forms.CheckBox CHK_ReplaceMega;
     }
 }

--- a/pk3DS/Subforms/Gen7/SMTE.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.cs
@@ -19,9 +19,10 @@ namespace pk3DS
         private readonly trdata7[] Trainers;
         private string[][] AltForms;
         private static int[] SpecialClasses;
-        private static int[] ImportantTrainers;
-        private static int[] FinalEvo;
-        private static int[] ReplaceLegend;
+        private static int[] ImportantTrainers = Main.Config.USUM ? Legal.ImportantTrainers_USUM : Legal.ImportantTrainers_SM;
+        private static int[] FinalEvo = Legal.FinalEvolutions_7;
+        private static int[] Legendary = Main.Config.USUM ? Legal.Legendary_USUM : Legal.Legendary_SM;
+        private static int[] Mythical = Main.Config.USUM ? Legal.Mythical_USUM : Legal.Mythical_SM;
         private static Dictionary<int, int[]> MegaDictionary;
         private int index = -1;
         private PictureBox[] pba;
@@ -38,7 +39,6 @@ namespace pk3DS
         private readonly string[] trClass = Main.Config.getText(TextName.TrainerClasses);
         private readonly TextData trText = Main.Config.getTextData(TextName.TrainerText);
         private readonly TextData TrainerNames;
-        
 
         public SMTE(byte[][] trc, byte[][] trd, byte[][] trp)
         {
@@ -58,12 +58,7 @@ namespace pk3DS
 
             CB_TrainerID.SelectedIndex = 0;
             CB_Moves.SelectedIndex = 0;
-            CHK_ReplaceLegend.Visible = Main.Config.USUM; // Team Rainbow Rocket only in USUM
             MegaDictionary = GiftEditor6.GetMegaDictionary(Main.Config);
-            
-            ImportantTrainers = Main.Config.USUM ? Legal.ImportantTrainers_USUM : Legal.ImportantTrainers_SM;
-            FinalEvo = Main.Config.USUM ? Legal.FinalEvolutions_USUM : Legal.FinalEvolutions_SM;
-            ReplaceLegend = Legal.Legendary_Mythical_USUM;
 
             if (CHK_RandomClass.Checked)
             {
@@ -633,6 +628,10 @@ namespace pk3DS
             };
             rnd.Initialize();
 
+            // add Legendary/Mythical to final evolutions if checked
+            if (CHK_L.Checked) FinalEvo = FinalEvo.Concat(Legendary).ToArray();
+            if (CHK_E.Checked) FinalEvo = FinalEvo.Concat(Mythical).ToArray();
+
             var banned = new List<int>(new[] { 165, 621, 464 }.Concat(Legal.Z_Moves)); // Struggle, Hyperspace Fury, Dark Void
             if (CHK_NoFixedDamage.Checked)
                 banned.AddRange(MoveRandomizer.FixedDamageMoves);
@@ -725,15 +724,6 @@ namespace pk3DS
                             pk.Species = species;
                             pk.Item = mega[Util.rand.Next(0, mega.Length)];
                             pk.Form = 0; // allow it to Mega Evolve naturally
-                        }
-
-                        // replaces Team Rainbow Rocket Legendaries with another Legendary
-                        else if (CHK_ReplaceLegend.Checked && ReplaceLegend.Contains(pk.Species))
-                        {
-                            int randLegend() => (int)(Util.rnd32() % ReplaceLegend.Length);
-                            pk.Species = ReplaceLegend[randLegend()];
-                            pk.Item = items[Util.rnd32() % items.Length];
-                            pk.Form = Randomizer.GetRandomForme(pk.Species, CHK_RandomMegaForm.Checked, true, Main.SpeciesStat);
                         }
                         
                         // every other pkm

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -20,9 +20,11 @@ namespace pk3DS
         private readonly string[] natures = Main.Config.getText(TextName.Natures);
         private readonly string[] types = Main.Config.getText(TextName.Types);
         private readonly int[] oldStarters;
-        private static int[] FinalEvo;
-        private static int[] ReplaceLegend;
-        private static int[] BasicStarter;
+        private static int[] FinalEvo = Legal.FinalEvolutions_7;
+        private static int[] Legendary = Main.Config.USUM ? Legal.Legendary_USUM : Legal.Legendary_SM;
+        private static int[] Mythical = Main.Config.USUM ? Legal.Mythical_USUM : Legal.Mythical_SM;
+        private static int[] ReplaceLegend = Legendary.Concat(Mythical).ToArray();
+        private static int[] BasicStarter = Legal.BasicStarters_7;
 
         private readonly string[] gender =
         {
@@ -154,9 +156,6 @@ namespace pk3DS
             LB_Gift.SelectedIndex = 0;
             LB_Encounter.SelectedIndex = 0;
             LB_Trade.SelectedIndex = 0;
-            FinalEvo = Main.Config.USUM ? Legal.FinalEvolutions_USUM : Legal.FinalEvolutions_SM;
-            ReplaceLegend = Main.Config.USUM ? Legal.Legendary_Mythical_USUM : Legal.Legendary_Mythical_SM;
-            BasicStarter = Legal.BasicStarters_7;
 
             // Select last tab (Randomization) by default in case info already randomized.
             TC_Tabs.SelectedIndex = TC_Tabs.TabCount - 1;
@@ -251,6 +250,9 @@ namespace pk3DS
         private void GetAllies()
         {
             var entry = Encounters[eEntry];
+
+            if (eEntry < 0)
+                return;
 
             // USUM has slots with SOS allies beyond slot 100, accommodate by trimming an extra character
             int endTrim = eEntry < 100 ? 5 : 6;
@@ -502,6 +504,11 @@ namespace pk3DS
                 rBST = CHK_BST.Checked,
             };
             specrand.Initialize();
+
+            // add Legendary/Mythical to final evolutions if checked
+            if (CHK_L.Checked) FinalEvo = FinalEvo.Concat(Legendary).ToArray();
+            if (CHK_E.Checked) FinalEvo = FinalEvo.Concat(Mythical).ToArray();
+
             return specrand;
         }
 


### PR DESCRIPTION
This PR reworks forcing fully evolved species and Legendary replacement.

Legendary/Mythical Pokémon were extracted from the fully evolved species array and moved into their own respective arrays. This fixes the previous problem of Legendary/Mythical Pokémon being forced onto the player when forcing fully-evolved species, regardless of whether `CHK_L` or `CHK_E` was checked or not.

Removed Legendary replacement for Team Rainbow Rocket since in-game it doesn't function as I'd intended; not gonna bother trying to code around it so the team only has 1 Legendary Pokémon.

Also add in the fix you mentioned from #382.