### PR TITLE
Fix #391: prevent Metronome Mode softlock

### DIFF
--- a/pk3DS/Subforms/Gen6/MoveEditor6.cs
+++ b/pk3DS/Subforms/Gen6/MoveEditor6.cs
@@ -209,10 +209,12 @@ namespace pk3DS
             for (int i = 0; i < CB_Move.Items.Count; i++)
             {
                 CB_Move.SelectedIndex = i;
-                if (CB_Move.SelectedIndex != 117)
+                if (CB_Move.SelectedIndex != 117 || CB_Move.SelectedIndex != 32)
                     NUD_PP.Value = 0;
                 if (CB_Move.SelectedIndex == 117)
                     NUD_PP.Value = 40;
+                if (CB_Move.SelectedIndex == 32)
+                    NUD_PP.Value = 1;
             }
             CB_Move.SelectedIndex = 0;
             WinFormsUtil.Alert("All Moves have had their Base PP values modified!");

--- a/pk3DS/Subforms/Gen7/MoveEditor7.cs
+++ b/pk3DS/Subforms/Gen7/MoveEditor7.cs
@@ -271,10 +271,12 @@ namespace pk3DS
             for (int i = 0; i < CB_Move.Items.Count; i++)
             {
                 CB_Move.SelectedIndex = i;
-                if (CB_Move.SelectedIndex != 117)
+                if (CB_Move.SelectedIndex != 117 || CB_Move.SelectedIndex != 32)
                     NUD_PP.Value = 0;
                 if (CB_Move.SelectedIndex == 117)
                     NUD_PP.Value = 40;
+                if (CB_Move.SelectedIndex == 32)
+                    NUD_PP.Value = 1;
             }
             CB_Move.SelectedIndex = 0;
             WinFormsUtil.Alert("All Moves have had their Base PP values modified!");


### PR DESCRIPTION
Pretty sure this is all that has to be changed...double checked and it looks like the catching tuts in all 6/7 games only ever use Tackle.