### PR TITLE
Port Move buttons (Current Levelup/High Attack Levelup) to StaticEncounter for Gen7

### DIFF
--- a/pk3DS/Subforms/Gen7/SMTE.Designer.cs
+++ b/pk3DS/Subforms/Gen7/SMTE.Designer.cs
@@ -1386,17 +1386,6 @@
             this.CB_Move1.Size = new System.Drawing.Size(121, 21);
             this.CB_Move1.TabIndex = 1;
             // 
-            // CB_Move4
-            // 
-            this.CB_Move4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.CB_Move4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.CB_Move4.FormattingEnabled = true;
-            this.CB_Move4.Location = new System.Drawing.Point(40, 82);
-            this.CB_Move4.Margin = new System.Windows.Forms.Padding(0);
-            this.CB_Move4.Name = "CB_Move4";
-            this.CB_Move4.Size = new System.Drawing.Size(121, 21);
-            this.CB_Move4.TabIndex = 2;
-            // 
             // CB_Move2
             // 
             this.CB_Move2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
@@ -1406,7 +1395,7 @@
             this.CB_Move2.Margin = new System.Windows.Forms.Padding(0);
             this.CB_Move2.Name = "CB_Move2";
             this.CB_Move2.Size = new System.Drawing.Size(121, 21);
-            this.CB_Move2.TabIndex = 1;
+            this.CB_Move2.TabIndex = 2;
             // 
             // CB_Move3
             // 
@@ -1417,7 +1406,18 @@
             this.CB_Move3.Margin = new System.Windows.Forms.Padding(0);
             this.CB_Move3.Name = "CB_Move3";
             this.CB_Move3.Size = new System.Drawing.Size(121, 21);
-            this.CB_Move3.TabIndex = 2;
+            this.CB_Move3.TabIndex = 3;
+            // 
+            // CB_Move4
+            // 
+            this.CB_Move4.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_Move4.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.CB_Move4.FormattingEnabled = true;
+            this.CB_Move4.Location = new System.Drawing.Point(40, 82);
+            this.CB_Move4.Margin = new System.Windows.Forms.Padding(0);
+            this.CB_Move4.Name = "CB_Move4";
+            this.CB_Move4.Size = new System.Drawing.Size(121, 21);
+            this.CB_Move4.TabIndex = 4;
             // 
             // L_TrainerName
             // 

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.Designer.cs
@@ -49,6 +49,9 @@
             this.NUD_GLevel = new System.Windows.Forms.NumericUpDown();
             this.LB_Gift = new System.Windows.Forms.ListBox();
             this.Tab_Encounters = new System.Windows.Forms.TabPage();
+            this.B_ClearSE = new System.Windows.Forms.Button();
+            this.B_CurrentAttackSE = new System.Windows.Forms.Button();
+            this.B_HighAttackSE = new System.Windows.Forms.Button();
             this.CB_EGender = new System.Windows.Forms.ComboBox();
             this.L_SOS1 = new System.Windows.Forms.Label();
             this.NUD_Ally1 = new System.Windows.Forms.NumericUpDown();
@@ -222,10 +225,11 @@
             this.TC_Tabs.Controls.Add(this.Tab_Encounters);
             this.TC_Tabs.Controls.Add(this.Tab_Trades);
             this.TC_Tabs.Controls.Add(this.Tab_Randomizer);
-            this.TC_Tabs.Location = new System.Drawing.Point(12, 11);
+            this.TC_Tabs.Location = new System.Drawing.Point(16, 14);
+            this.TC_Tabs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.TC_Tabs.Name = "TC_Tabs";
             this.TC_Tabs.SelectedIndex = 0;
-            this.TC_Tabs.Size = new System.Drawing.Size(506, 538);
+            this.TC_Tabs.Size = new System.Drawing.Size(675, 662);
             this.TC_Tabs.TabIndex = 0;
             // 
             // Tab_Gifts
@@ -248,9 +252,10 @@
             this.Tab_Gifts.Controls.Add(this.L_GSpecies);
             this.Tab_Gifts.Controls.Add(this.NUD_GLevel);
             this.Tab_Gifts.Controls.Add(this.LB_Gift);
-            this.Tab_Gifts.Location = new System.Drawing.Point(4, 22);
+            this.Tab_Gifts.Location = new System.Drawing.Point(4, 25);
+            this.Tab_Gifts.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Tab_Gifts.Name = "Tab_Gifts";
-            this.Tab_Gifts.Size = new System.Drawing.Size(498, 512);
+            this.Tab_Gifts.Size = new System.Drawing.Size(667, 633);
             this.Tab_Gifts.TabIndex = 2;
             this.Tab_Gifts.Text = "Gifts";
             this.Tab_Gifts.UseVisualStyleBackColor = true;
@@ -258,33 +263,39 @@
             // CB_GAbility
             // 
             this.CB_GAbility.FormattingEnabled = true;
-            this.CB_GAbility.Location = new System.Drawing.Point(187, 71);
+            this.CB_GAbility.Location = new System.Drawing.Point(249, 87);
+            this.CB_GAbility.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_GAbility.Name = "CB_GAbility";
-            this.CB_GAbility.Size = new System.Drawing.Size(136, 21);
+            this.CB_GAbility.Size = new System.Drawing.Size(180, 24);
             this.CB_GAbility.TabIndex = 513;
             // 
             // L_GAbility
             // 
-            this.L_GAbility.Location = new System.Drawing.Point(131, 69);
+            this.L_GAbility.Location = new System.Drawing.Point(175, 85);
+            this.L_GAbility.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GAbility.Name = "L_GAbility";
-            this.L_GAbility.Size = new System.Drawing.Size(55, 23);
+            this.L_GAbility.Size = new System.Drawing.Size(73, 28);
             this.L_GAbility.TabIndex = 512;
             this.L_GAbility.Text = "Ability:";
             this.L_GAbility.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_GNature
             // 
+            this.CB_GNature.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_GNature.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_GNature.FormattingEnabled = true;
-            this.CB_GNature.Location = new System.Drawing.Point(187, 115);
+            this.CB_GNature.Location = new System.Drawing.Point(249, 142);
+            this.CB_GNature.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_GNature.Name = "CB_GNature";
-            this.CB_GNature.Size = new System.Drawing.Size(136, 21);
+            this.CB_GNature.Size = new System.Drawing.Size(180, 24);
             this.CB_GNature.TabIndex = 511;
             // 
             // L_GNature
             // 
-            this.L_GNature.Location = new System.Drawing.Point(131, 113);
+            this.L_GNature.Location = new System.Drawing.Point(175, 139);
+            this.L_GNature.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GNature.Name = "L_GNature";
-            this.L_GNature.Size = new System.Drawing.Size(55, 23);
+            this.L_GNature.Size = new System.Drawing.Size(73, 28);
             this.L_GNature.TabIndex = 510;
             this.L_GNature.Text = "Nature:";
             this.L_GNature.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -292,9 +303,10 @@
             // CHK_IsEgg
             // 
             this.CHK_IsEgg.AutoSize = true;
-            this.CHK_IsEgg.Location = new System.Drawing.Point(187, 193);
+            this.CHK_IsEgg.Location = new System.Drawing.Point(249, 238);
+            this.CHK_IsEgg.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_IsEgg.Name = "CHK_IsEgg";
-            this.CHK_IsEgg.Size = new System.Drawing.Size(56, 17);
+            this.CHK_IsEgg.Size = new System.Drawing.Size(65, 20);
             this.CHK_IsEgg.TabIndex = 509;
             this.CHK_IsEgg.Text = "Is Egg";
             this.CHK_IsEgg.UseVisualStyleBackColor = true;
@@ -302,26 +314,31 @@
             // CHK_GIV3
             // 
             this.CHK_GIV3.AutoSize = true;
-            this.CHK_GIV3.Location = new System.Drawing.Point(187, 178);
+            this.CHK_GIV3.Location = new System.Drawing.Point(249, 219);
+            this.CHK_GIV3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_GIV3.Name = "CHK_GIV3";
-            this.CHK_GIV3.Size = new System.Drawing.Size(42, 17);
+            this.CHK_GIV3.Size = new System.Drawing.Size(46, 20);
             this.CHK_GIV3.TabIndex = 508;
             this.CHK_GIV3.Text = "3IV";
             this.CHK_GIV3.UseVisualStyleBackColor = true;
             // 
             // CB_SpecialMove
             // 
+            this.CB_SpecialMove.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_SpecialMove.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_SpecialMove.FormattingEnabled = true;
-            this.CB_SpecialMove.Location = new System.Drawing.Point(187, 137);
+            this.CB_SpecialMove.Location = new System.Drawing.Point(249, 169);
+            this.CB_SpecialMove.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_SpecialMove.Name = "CB_SpecialMove";
-            this.CB_SpecialMove.Size = new System.Drawing.Size(136, 21);
+            this.CB_SpecialMove.Size = new System.Drawing.Size(180, 24);
             this.CB_SpecialMove.TabIndex = 507;
             // 
             // L_SpecialMove
             // 
-            this.L_SpecialMove.Location = new System.Drawing.Point(121, 135);
+            this.L_SpecialMove.Location = new System.Drawing.Point(161, 166);
+            this.L_SpecialMove.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SpecialMove.Name = "L_SpecialMove";
-            this.L_SpecialMove.Size = new System.Drawing.Size(65, 23);
+            this.L_SpecialMove.Size = new System.Drawing.Size(87, 28);
             this.L_SpecialMove.TabIndex = 506;
             this.L_SpecialMove.Text = "Gift Move:";
             this.L_SpecialMove.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -329,58 +346,68 @@
             // CHK_G_Lock
             // 
             this.CHK_G_Lock.AutoSize = true;
-            this.CHK_G_Lock.Location = new System.Drawing.Point(187, 163);
+            this.CHK_G_Lock.Location = new System.Drawing.Point(249, 201);
+            this.CHK_G_Lock.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G_Lock.Name = "CHK_G_Lock";
-            this.CHK_G_Lock.Size = new System.Drawing.Size(79, 17);
+            this.CHK_G_Lock.Size = new System.Drawing.Size(92, 20);
             this.CHK_G_Lock.TabIndex = 19;
             this.CHK_G_Lock.Text = "Shiny Lock";
             this.CHK_G_Lock.UseVisualStyleBackColor = true;
             // 
             // CB_GHeldItem
             // 
+            this.CB_GHeldItem.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_GHeldItem.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_GHeldItem.FormattingEnabled = true;
-            this.CB_GHeldItem.Location = new System.Drawing.Point(187, 93);
+            this.CB_GHeldItem.Location = new System.Drawing.Point(249, 114);
+            this.CB_GHeldItem.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_GHeldItem.Name = "CB_GHeldItem";
-            this.CB_GHeldItem.Size = new System.Drawing.Size(136, 21);
+            this.CB_GHeldItem.Size = new System.Drawing.Size(180, 24);
             this.CB_GHeldItem.TabIndex = 8;
             // 
             // L_GHeldItem
             // 
-            this.L_GHeldItem.Location = new System.Drawing.Point(131, 91);
+            this.L_GHeldItem.Location = new System.Drawing.Point(175, 112);
+            this.L_GHeldItem.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GHeldItem.Name = "L_GHeldItem";
-            this.L_GHeldItem.Size = new System.Drawing.Size(55, 23);
+            this.L_GHeldItem.Size = new System.Drawing.Size(73, 28);
             this.L_GHeldItem.TabIndex = 7;
             this.L_GHeldItem.Text = "Held Item:";
             this.L_GHeldItem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_GSpecies
             // 
+            this.CB_GSpecies.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_GSpecies.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_GSpecies.FormattingEnabled = true;
-            this.CB_GSpecies.Location = new System.Drawing.Point(187, 7);
+            this.CB_GSpecies.Location = new System.Drawing.Point(249, 9);
+            this.CB_GSpecies.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_GSpecies.Name = "CB_GSpecies";
-            this.CB_GSpecies.Size = new System.Drawing.Size(136, 21);
+            this.CB_GSpecies.Size = new System.Drawing.Size(180, 24);
             this.CB_GSpecies.TabIndex = 6;
             this.CB_GSpecies.SelectedIndexChanged += new System.EventHandler(this.ChangeSpecies);
             // 
             // L_GForm
             // 
-            this.L_GForm.Location = new System.Drawing.Point(131, 47);
+            this.L_GForm.Location = new System.Drawing.Point(175, 58);
+            this.L_GForm.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GForm.Name = "L_GForm";
-            this.L_GForm.Size = new System.Drawing.Size(55, 23);
+            this.L_GForm.Size = new System.Drawing.Size(73, 28);
             this.L_GForm.TabIndex = 5;
             this.L_GForm.Text = "Form:";
             this.L_GForm.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_GForm
             // 
-            this.NUD_GForm.Location = new System.Drawing.Point(187, 50);
+            this.NUD_GForm.Location = new System.Drawing.Point(249, 62);
+            this.NUD_GForm.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_GForm.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.NUD_GForm.Name = "NUD_GForm";
-            this.NUD_GForm.Size = new System.Drawing.Size(48, 20);
+            this.NUD_GForm.Size = new System.Drawing.Size(64, 22);
             this.NUD_GForm.TabIndex = 4;
             this.NUD_GForm.Value = new decimal(new int[] {
             100,
@@ -390,27 +417,30 @@
             // 
             // L_GLevel
             // 
-            this.L_GLevel.Location = new System.Drawing.Point(131, 26);
+            this.L_GLevel.Location = new System.Drawing.Point(175, 32);
+            this.L_GLevel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GLevel.Name = "L_GLevel";
-            this.L_GLevel.Size = new System.Drawing.Size(55, 23);
+            this.L_GLevel.Size = new System.Drawing.Size(73, 28);
             this.L_GLevel.TabIndex = 3;
             this.L_GLevel.Text = "Level:";
             this.L_GLevel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_GSpecies
             // 
-            this.L_GSpecies.Location = new System.Drawing.Point(131, 5);
+            this.L_GSpecies.Location = new System.Drawing.Point(175, 6);
+            this.L_GSpecies.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_GSpecies.Name = "L_GSpecies";
-            this.L_GSpecies.Size = new System.Drawing.Size(55, 23);
+            this.L_GSpecies.Size = new System.Drawing.Size(73, 28);
             this.L_GSpecies.TabIndex = 2;
             this.L_GSpecies.Text = "Species:";
             this.L_GSpecies.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_GLevel
             // 
-            this.NUD_GLevel.Location = new System.Drawing.Point(187, 29);
+            this.NUD_GLevel.Location = new System.Drawing.Point(249, 36);
+            this.NUD_GLevel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_GLevel.Name = "NUD_GLevel";
-            this.NUD_GLevel.Size = new System.Drawing.Size(48, 20);
+            this.NUD_GLevel.Size = new System.Drawing.Size(64, 22);
             this.NUD_GLevel.TabIndex = 1;
             this.NUD_GLevel.Value = new decimal(new int[] {
             100,
@@ -423,14 +453,19 @@
             this.LB_Gift.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.LB_Gift.FormattingEnabled = true;
-            this.LB_Gift.Location = new System.Drawing.Point(3, 3);
+            this.LB_Gift.ItemHeight = 16;
+            this.LB_Gift.Location = new System.Drawing.Point(4, 4);
+            this.LB_Gift.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.LB_Gift.Name = "LB_Gift";
-            this.LB_Gift.Size = new System.Drawing.Size(115, 498);
+            this.LB_Gift.Size = new System.Drawing.Size(152, 612);
             this.LB_Gift.TabIndex = 0;
             this.LB_Gift.SelectedIndexChanged += new System.EventHandler(this.LB_Gift_SelectedIndexChanged);
             // 
             // Tab_Encounters
             // 
+            this.Tab_Encounters.Controls.Add(this.B_ClearSE);
+            this.Tab_Encounters.Controls.Add(this.B_CurrentAttackSE);
+            this.Tab_Encounters.Controls.Add(this.B_HighAttackSE);
             this.Tab_Encounters.Controls.Add(this.CB_EGender);
             this.Tab_Encounters.Controls.Add(this.L_SOS1);
             this.Tab_Encounters.Controls.Add(this.NUD_Ally1);
@@ -459,34 +494,71 @@
             this.Tab_Encounters.Controls.Add(this.LB_Encounter);
             this.Tab_Encounters.Controls.Add(this.L_Ally2);
             this.Tab_Encounters.Controls.Add(this.L_Ally1);
-            this.Tab_Encounters.Location = new System.Drawing.Point(4, 22);
+            this.Tab_Encounters.Location = new System.Drawing.Point(4, 25);
+            this.Tab_Encounters.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Tab_Encounters.Name = "Tab_Encounters";
-            this.Tab_Encounters.Padding = new System.Windows.Forms.Padding(3);
-            this.Tab_Encounters.Size = new System.Drawing.Size(498, 512);
+            this.Tab_Encounters.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Tab_Encounters.Size = new System.Drawing.Size(667, 633);
             this.Tab_Encounters.TabIndex = 0;
             this.Tab_Encounters.Text = "Encounters";
             this.Tab_Encounters.UseVisualStyleBackColor = true;
             // 
+            // B_ClearSE
+            // 
+            this.B_ClearSE.Location = new System.Drawing.Point(357, 421);
+            this.B_ClearSE.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.B_ClearSE.Name = "B_ClearSE";
+            this.B_ClearSE.Size = new System.Drawing.Size(124, 28);
+            this.B_ClearSE.TabIndex = 529;
+            this.B_ClearSE.Text = "Clear";
+            this.B_ClearSE.UseVisualStyleBackColor = true;
+            this.B_ClearSE.Click += new System.EventHandler(this.B_ClearSE_Click);
+            // 
+            // B_CurrentAttackSE
+            // 
+            this.B_CurrentAttackSE.Location = new System.Drawing.Point(357, 317);
+            this.B_CurrentAttackSE.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.B_CurrentAttackSE.Name = "B_CurrentAttackSE";
+            this.B_CurrentAttackSE.Size = new System.Drawing.Size(124, 49);
+            this.B_CurrentAttackSE.TabIndex = 528;
+            this.B_CurrentAttackSE.Text = "Current Level Levelup Moves";
+            this.B_CurrentAttackSE.UseVisualStyleBackColor = true;
+            this.B_CurrentAttackSE.Click += new System.EventHandler(this.B_CurrentAttackSE_Click);
+            // 
+            // B_HighAttackSE
+            // 
+            this.B_HighAttackSE.Location = new System.Drawing.Point(357, 369);
+            this.B_HighAttackSE.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.B_HighAttackSE.Name = "B_HighAttackSE";
+            this.B_HighAttackSE.Size = new System.Drawing.Size(124, 49);
+            this.B_HighAttackSE.TabIndex = 527;
+            this.B_HighAttackSE.Text = "High Attacking Levelup Moves";
+            this.B_HighAttackSE.UseVisualStyleBackColor = true;
+            this.B_HighAttackSE.Click += new System.EventHandler(this.B_HighAttackSE_Click);
+            // 
             // CB_EGender
             // 
             this.CB_EGender.FormattingEnabled = true;
-            this.CB_EGender.Location = new System.Drawing.Point(187, 71);
+            this.CB_EGender.Location = new System.Drawing.Point(249, 87);
+            this.CB_EGender.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EGender.Name = "CB_EGender";
-            this.CB_EGender.Size = new System.Drawing.Size(136, 21);
+            this.CB_EGender.Size = new System.Drawing.Size(180, 24);
             this.CB_EGender.TabIndex = 526;
             // 
             // L_SOS1
             // 
-            this.L_SOS1.Location = new System.Drawing.Point(126, 178);
+            this.L_SOS1.Location = new System.Drawing.Point(168, 219);
+            this.L_SOS1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SOS1.Name = "L_SOS1";
-            this.L_SOS1.Size = new System.Drawing.Size(60, 23);
+            this.L_SOS1.Size = new System.Drawing.Size(80, 28);
             this.L_SOS1.TabIndex = 523;
             this.L_SOS1.Text = "SOS Ally 1:";
             this.L_SOS1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_Ally1
             // 
-            this.NUD_Ally1.Location = new System.Drawing.Point(187, 181);
+            this.NUD_Ally1.Location = new System.Drawing.Point(249, 223);
+            this.NUD_Ally1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_Ally1.Maximum = new decimal(new int[] {
             251,
             0,
@@ -498,21 +570,23 @@
             0,
             -2147483648});
             this.NUD_Ally1.Name = "NUD_Ally1";
-            this.NUD_Ally1.Size = new System.Drawing.Size(48, 20);
+            this.NUD_Ally1.Size = new System.Drawing.Size(64, 22);
             this.NUD_Ally1.TabIndex = 522;
             // 
             // L_SOS2
             // 
-            this.L_SOS2.Location = new System.Drawing.Point(126, 199);
+            this.L_SOS2.Location = new System.Drawing.Point(168, 245);
+            this.L_SOS2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SOS2.Name = "L_SOS2";
-            this.L_SOS2.Size = new System.Drawing.Size(60, 23);
+            this.L_SOS2.Size = new System.Drawing.Size(80, 28);
             this.L_SOS2.TabIndex = 521;
             this.L_SOS2.Text = "SOS Ally 2:";
             this.L_SOS2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_Ally2
             // 
-            this.NUD_Ally2.Location = new System.Drawing.Point(187, 202);
+            this.NUD_Ally2.Location = new System.Drawing.Point(249, 249);
+            this.NUD_Ally2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_Ally2.Maximum = new decimal(new int[] {
             251,
             0,
@@ -524,14 +598,15 @@
             0,
             -2147483648});
             this.NUD_Ally2.Name = "NUD_Ally2";
-            this.NUD_Ally2.Size = new System.Drawing.Size(48, 20);
+            this.NUD_Ally2.Size = new System.Drawing.Size(64, 22);
             this.NUD_Ally2.TabIndex = 520;
             // 
             // L_EGender
             // 
-            this.L_EGender.Location = new System.Drawing.Point(131, 69);
+            this.L_EGender.Location = new System.Drawing.Point(175, 85);
+            this.L_EGender.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_EGender.Name = "L_EGender";
-            this.L_EGender.Size = new System.Drawing.Size(55, 23);
+            this.L_EGender.Size = new System.Drawing.Size(73, 28);
             this.L_EGender.TabIndex = 519;
             this.L_EGender.Text = "Gender:";
             this.L_EGender.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -539,16 +614,18 @@
             // CB_EAbility
             // 
             this.CB_EAbility.FormattingEnabled = true;
-            this.CB_EAbility.Location = new System.Drawing.Point(187, 93);
+            this.CB_EAbility.Location = new System.Drawing.Point(249, 114);
+            this.CB_EAbility.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EAbility.Name = "CB_EAbility";
-            this.CB_EAbility.Size = new System.Drawing.Size(136, 21);
+            this.CB_EAbility.Size = new System.Drawing.Size(180, 24);
             this.CB_EAbility.TabIndex = 517;
             // 
             // L_EAbility
             // 
-            this.L_EAbility.Location = new System.Drawing.Point(131, 91);
+            this.L_EAbility.Location = new System.Drawing.Point(175, 112);
+            this.L_EAbility.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_EAbility.Name = "L_EAbility";
-            this.L_EAbility.Size = new System.Drawing.Size(55, 23);
+            this.L_EAbility.Size = new System.Drawing.Size(73, 28);
             this.L_EAbility.TabIndex = 516;
             this.L_EAbility.Text = "Ability:";
             this.L_EAbility.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -556,26 +633,31 @@
             // CHK_EIV3
             // 
             this.CHK_EIV3.AutoSize = true;
-            this.CHK_EIV3.Location = new System.Drawing.Point(187, 240);
+            this.CHK_EIV3.Location = new System.Drawing.Point(249, 295);
+            this.CHK_EIV3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_EIV3.Name = "CHK_EIV3";
-            this.CHK_EIV3.Size = new System.Drawing.Size(42, 17);
+            this.CHK_EIV3.Size = new System.Drawing.Size(46, 20);
             this.CHK_EIV3.TabIndex = 504;
             this.CHK_EIV3.Text = "3IV";
             this.CHK_EIV3.UseVisualStyleBackColor = true;
             // 
             // CB_ENature
             // 
+            this.CB_ENature.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_ENature.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_ENature.FormattingEnabled = true;
-            this.CB_ENature.Location = new System.Drawing.Point(187, 137);
+            this.CB_ENature.Location = new System.Drawing.Point(249, 169);
+            this.CB_ENature.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_ENature.Name = "CB_ENature";
-            this.CB_ENature.Size = new System.Drawing.Size(136, 21);
+            this.CB_ENature.Size = new System.Drawing.Size(180, 24);
             this.CB_ENature.TabIndex = 503;
             // 
             // L_ENature
             // 
-            this.L_ENature.Location = new System.Drawing.Point(131, 135);
+            this.L_ENature.Location = new System.Drawing.Point(175, 166);
+            this.L_ENature.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_ENature.Name = "L_ENature";
-            this.L_ENature.Size = new System.Drawing.Size(55, 23);
+            this.L_ENature.Size = new System.Drawing.Size(73, 28);
             this.L_ENature.TabIndex = 502;
             this.L_ENature.Text = "Nature:";
             this.L_ENature.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -594,23 +676,26 @@
             this.GB_EEVs.Controls.Add(this.label3);
             this.GB_EEVs.Controls.Add(this.label4);
             this.GB_EEVs.Controls.Add(this.label5);
-            this.GB_EEVs.Location = new System.Drawing.Point(280, 371);
+            this.GB_EEVs.Location = new System.Drawing.Point(373, 457);
+            this.GB_EEVs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.GB_EEVs.Name = "GB_EEVs";
-            this.GB_EEVs.Size = new System.Drawing.Size(160, 112);
+            this.GB_EEVs.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.GB_EEVs.Size = new System.Drawing.Size(213, 138);
             this.GB_EEVs.TabIndex = 501;
             this.GB_EEVs.TabStop = false;
             this.GB_EEVs.Text = "EVs";
             // 
             // NUD_EV5
             // 
-            this.NUD_EV5.Location = new System.Drawing.Point(111, 82);
+            this.NUD_EV5.Location = new System.Drawing.Point(148, 101);
+            this.NUD_EV5.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV5.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV5.Name = "NUD_EV5";
-            this.NUD_EV5.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV5.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV5.TabIndex = 515;
             this.NUD_EV5.Value = new decimal(new int[] {
             252,
@@ -620,14 +705,15 @@
             // 
             // NUD_EV4
             // 
-            this.NUD_EV4.Location = new System.Drawing.Point(111, 51);
+            this.NUD_EV4.Location = new System.Drawing.Point(148, 63);
+            this.NUD_EV4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV4.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV4.Name = "NUD_EV4";
-            this.NUD_EV4.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV4.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV4.TabIndex = 516;
             this.NUD_EV4.Value = new decimal(new int[] {
             252,
@@ -637,14 +723,15 @@
             // 
             // NUD_EV3
             // 
-            this.NUD_EV3.Location = new System.Drawing.Point(111, 20);
+            this.NUD_EV3.Location = new System.Drawing.Point(148, 25);
+            this.NUD_EV3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV3.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV3.Name = "NUD_EV3";
-            this.NUD_EV3.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV3.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV3.TabIndex = 514;
             this.NUD_EV3.Value = new decimal(new int[] {
             252,
@@ -654,14 +741,15 @@
             // 
             // NUD_EV2
             // 
-            this.NUD_EV2.Location = new System.Drawing.Point(33, 82);
+            this.NUD_EV2.Location = new System.Drawing.Point(44, 101);
+            this.NUD_EV2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV2.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV2.Name = "NUD_EV2";
-            this.NUD_EV2.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV2.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV2.TabIndex = 502;
             this.NUD_EV2.Value = new decimal(new int[] {
             252,
@@ -671,14 +759,15 @@
             // 
             // NUD_EV1
             // 
-            this.NUD_EV1.Location = new System.Drawing.Point(33, 51);
+            this.NUD_EV1.Location = new System.Drawing.Point(44, 63);
+            this.NUD_EV1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV1.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV1.Name = "NUD_EV1";
-            this.NUD_EV1.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV1.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV1.TabIndex = 513;
             this.NUD_EV1.Value = new decimal(new int[] {
             252,
@@ -688,41 +777,45 @@
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(4, 18);
+            this.label2.Location = new System.Drawing.Point(5, 22);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(29, 21);
+            this.label2.Size = new System.Drawing.Size(39, 26);
             this.label2.TabIndex = 507;
             this.label2.Text = "HP:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label7
             // 
-            this.label7.Location = new System.Drawing.Point(4, 80);
+            this.label7.Location = new System.Drawing.Point(5, 98);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(29, 21);
+            this.label7.Size = new System.Drawing.Size(39, 26);
             this.label7.TabIndex = 509;
             this.label7.Text = "Def:";
             this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label6
             // 
-            this.label6.Location = new System.Drawing.Point(7, 49);
+            this.label6.Location = new System.Drawing.Point(9, 60);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(26, 21);
+            this.label6.Size = new System.Drawing.Size(35, 26);
             this.label6.TabIndex = 508;
             this.label6.Text = "Atk:";
             this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_EV0
             // 
-            this.NUD_EV0.Location = new System.Drawing.Point(33, 20);
+            this.NUD_EV0.Location = new System.Drawing.Point(44, 25);
+            this.NUD_EV0.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EV0.Maximum = new decimal(new int[] {
             252,
             0,
             0,
             0});
             this.NUD_EV0.Name = "NUD_EV0";
-            this.NUD_EV0.Size = new System.Drawing.Size(40, 20);
+            this.NUD_EV0.Size = new System.Drawing.Size(53, 22);
             this.NUD_EV0.TabIndex = 501;
             this.NUD_EV0.Value = new decimal(new int[] {
             252,
@@ -732,27 +825,30 @@
             // 
             // label3
             // 
-            this.label3.Location = new System.Drawing.Point(79, 49);
+            this.label3.Location = new System.Drawing.Point(105, 60);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(31, 21);
+            this.label3.Size = new System.Drawing.Size(41, 26);
             this.label3.TabIndex = 512;
             this.label3.Text = "SpD:";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label4
             // 
-            this.label4.Location = new System.Drawing.Point(79, 80);
+            this.label4.Location = new System.Drawing.Point(105, 98);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(31, 21);
+            this.label4.Size = new System.Drawing.Size(41, 26);
             this.label4.TabIndex = 511;
             this.label4.Text = "Spe:";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label5
             // 
-            this.label5.Location = new System.Drawing.Point(79, 18);
+            this.label5.Location = new System.Drawing.Point(105, 22);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(31, 21);
+            this.label5.Size = new System.Drawing.Size(41, 26);
             this.label5.TabIndex = 510;
             this.label5.Text = "SpA:";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -771,25 +867,29 @@
             this.GB_EIVs.Controls.Add(this.NUD_EIV0);
             this.GB_EIVs.Controls.Add(this.L_ATK);
             this.GB_EIVs.Controls.Add(this.L_DEF);
-            this.GB_EIVs.Location = new System.Drawing.Point(129, 371);
+            this.GB_EIVs.Location = new System.Drawing.Point(172, 457);
+            this.GB_EIVs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.GB_EIVs.Name = "GB_EIVs";
-            this.GB_EIVs.Size = new System.Drawing.Size(148, 112);
+            this.GB_EIVs.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.GB_EIVs.Size = new System.Drawing.Size(197, 138);
             this.GB_EIVs.TabIndex = 21;
             this.GB_EIVs.TabStop = false;
             this.GB_EIVs.Text = "IVs";
             // 
             // L_HP
             // 
-            this.L_HP.Location = new System.Drawing.Point(4, 16);
+            this.L_HP.Location = new System.Drawing.Point(5, 20);
+            this.L_HP.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_HP.Name = "L_HP";
-            this.L_HP.Size = new System.Drawing.Size(29, 21);
+            this.L_HP.Size = new System.Drawing.Size(39, 26);
             this.L_HP.TabIndex = 495;
             this.L_HP.Text = "HP:";
             this.L_HP.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_EIV3
             // 
-            this.NUD_EIV3.Location = new System.Drawing.Point(104, 18);
+            this.NUD_EIV3.Location = new System.Drawing.Point(139, 22);
+            this.NUD_EIV3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV3.Maximum = new decimal(new int[] {
             31,
             0,
@@ -801,7 +901,7 @@
             0,
             -2147483648});
             this.NUD_EIV3.Name = "NUD_EIV3";
-            this.NUD_EIV3.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV3.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV3.TabIndex = 492;
             this.NUD_EIV3.Value = new decimal(new int[] {
             31,
@@ -811,7 +911,8 @@
             // 
             // NUD_EIV4
             // 
-            this.NUD_EIV4.Location = new System.Drawing.Point(104, 49);
+            this.NUD_EIV4.Location = new System.Drawing.Point(139, 60);
+            this.NUD_EIV4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV4.Maximum = new decimal(new int[] {
             31,
             0,
@@ -823,7 +924,7 @@
             0,
             -2147483648});
             this.NUD_EIV4.Name = "NUD_EIV4";
-            this.NUD_EIV4.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV4.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV4.TabIndex = 493;
             this.NUD_EIV4.Value = new decimal(new int[] {
             31,
@@ -833,7 +934,8 @@
             // 
             // NUD_EIV5
             // 
-            this.NUD_EIV5.Location = new System.Drawing.Point(104, 80);
+            this.NUD_EIV5.Location = new System.Drawing.Point(139, 98);
+            this.NUD_EIV5.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV5.Maximum = new decimal(new int[] {
             31,
             0,
@@ -845,7 +947,7 @@
             0,
             -2147483648});
             this.NUD_EIV5.Name = "NUD_EIV5";
-            this.NUD_EIV5.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV5.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV5.TabIndex = 494;
             this.NUD_EIV5.Value = new decimal(new int[] {
             31,
@@ -855,34 +957,38 @@
             // 
             // L_SPD
             // 
-            this.L_SPD.Location = new System.Drawing.Point(73, 47);
+            this.L_SPD.Location = new System.Drawing.Point(97, 58);
+            this.L_SPD.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SPD.Name = "L_SPD";
-            this.L_SPD.Size = new System.Drawing.Size(31, 21);
+            this.L_SPD.Size = new System.Drawing.Size(41, 26);
             this.L_SPD.TabIndex = 500;
             this.L_SPD.Text = "SpD:";
             this.L_SPD.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_SPE
             // 
-            this.L_SPE.Location = new System.Drawing.Point(73, 78);
+            this.L_SPE.Location = new System.Drawing.Point(97, 96);
+            this.L_SPE.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SPE.Name = "L_SPE";
-            this.L_SPE.Size = new System.Drawing.Size(31, 21);
+            this.L_SPE.Size = new System.Drawing.Size(41, 26);
             this.L_SPE.TabIndex = 499;
             this.L_SPE.Text = "Spe:";
             this.L_SPE.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_SPA
             // 
-            this.L_SPA.Location = new System.Drawing.Point(73, 16);
+            this.L_SPA.Location = new System.Drawing.Point(97, 20);
+            this.L_SPA.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_SPA.Name = "L_SPA";
-            this.L_SPA.Size = new System.Drawing.Size(31, 21);
+            this.L_SPA.Size = new System.Drawing.Size(41, 26);
             this.L_SPA.TabIndex = 498;
             this.L_SPA.Text = "SpA:";
             this.L_SPA.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_EIV2
             // 
-            this.NUD_EIV2.Location = new System.Drawing.Point(33, 80);
+            this.NUD_EIV2.Location = new System.Drawing.Point(44, 98);
+            this.NUD_EIV2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV2.Maximum = new decimal(new int[] {
             31,
             0,
@@ -894,7 +1000,7 @@
             0,
             -2147483648});
             this.NUD_EIV2.Name = "NUD_EIV2";
-            this.NUD_EIV2.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV2.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV2.TabIndex = 491;
             this.NUD_EIV2.Value = new decimal(new int[] {
             31,
@@ -904,7 +1010,8 @@
             // 
             // NUD_EIV1
             // 
-            this.NUD_EIV1.Location = new System.Drawing.Point(33, 49);
+            this.NUD_EIV1.Location = new System.Drawing.Point(44, 60);
+            this.NUD_EIV1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV1.Maximum = new decimal(new int[] {
             31,
             0,
@@ -916,7 +1023,7 @@
             0,
             -2147483648});
             this.NUD_EIV1.Name = "NUD_EIV1";
-            this.NUD_EIV1.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV1.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV1.TabIndex = 490;
             this.NUD_EIV1.Value = new decimal(new int[] {
             31,
@@ -926,7 +1033,8 @@
             // 
             // NUD_EIV0
             // 
-            this.NUD_EIV0.Location = new System.Drawing.Point(33, 18);
+            this.NUD_EIV0.Location = new System.Drawing.Point(44, 22);
+            this.NUD_EIV0.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EIV0.Maximum = new decimal(new int[] {
             31,
             0,
@@ -938,7 +1046,7 @@
             0,
             -2147483648});
             this.NUD_EIV0.Name = "NUD_EIV0";
-            this.NUD_EIV0.Size = new System.Drawing.Size(34, 20);
+            this.NUD_EIV0.Size = new System.Drawing.Size(45, 22);
             this.NUD_EIV0.TabIndex = 489;
             this.NUD_EIV0.Value = new decimal(new int[] {
             31,
@@ -948,45 +1056,52 @@
             // 
             // L_ATK
             // 
-            this.L_ATK.Location = new System.Drawing.Point(7, 47);
+            this.L_ATK.Location = new System.Drawing.Point(9, 58);
+            this.L_ATK.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_ATK.Name = "L_ATK";
-            this.L_ATK.Size = new System.Drawing.Size(26, 21);
+            this.L_ATK.Size = new System.Drawing.Size(35, 26);
             this.L_ATK.TabIndex = 496;
             this.L_ATK.Text = "Atk:";
             this.L_ATK.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_DEF
             // 
-            this.L_DEF.Location = new System.Drawing.Point(4, 78);
+            this.L_DEF.Location = new System.Drawing.Point(5, 96);
+            this.L_DEF.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_DEF.Name = "L_DEF";
-            this.L_DEF.Size = new System.Drawing.Size(29, 21);
+            this.L_DEF.Size = new System.Drawing.Size(39, 26);
             this.L_DEF.TabIndex = 497;
             this.L_DEF.Text = "Def:";
             this.L_DEF.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_Aura
             // 
-            this.L_Aura.Location = new System.Drawing.Point(131, 157);
+            this.L_Aura.Location = new System.Drawing.Point(175, 193);
+            this.L_Aura.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_Aura.Name = "L_Aura";
-            this.L_Aura.Size = new System.Drawing.Size(55, 23);
+            this.L_Aura.Size = new System.Drawing.Size(73, 28);
             this.L_Aura.TabIndex = 22;
             this.L_Aura.Text = "Aura:";
             this.L_Aura.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_Aura
             // 
+            this.CB_Aura.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_Aura.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Aura.FormattingEnabled = true;
-            this.CB_Aura.Location = new System.Drawing.Point(187, 159);
+            this.CB_Aura.Location = new System.Drawing.Point(249, 196);
+            this.CB_Aura.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_Aura.Name = "CB_Aura";
-            this.CB_Aura.Size = new System.Drawing.Size(136, 21);
+            this.CB_Aura.Size = new System.Drawing.Size(180, 24);
             this.CB_Aura.TabIndex = 21;
             // 
             // CHK_ShinyLock
             // 
             this.CHK_ShinyLock.AutoSize = true;
-            this.CHK_ShinyLock.Location = new System.Drawing.Point(187, 225);
+            this.CHK_ShinyLock.Location = new System.Drawing.Point(249, 277);
+            this.CHK_ShinyLock.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_ShinyLock.Name = "CHK_ShinyLock";
-            this.CHK_ShinyLock.Size = new System.Drawing.Size(79, 17);
+            this.CHK_ShinyLock.Size = new System.Drawing.Size(92, 20);
             this.CHK_ShinyLock.TabIndex = 18;
             this.CHK_ShinyLock.Text = "Shiny Lock";
             this.CHK_ShinyLock.UseVisualStyleBackColor = true;
@@ -997,90 +1112,113 @@
             this.GB_EMoves.Controls.Add(this.CB_EMove2);
             this.GB_EMoves.Controls.Add(this.CB_EMove1);
             this.GB_EMoves.Controls.Add(this.CB_EMove0);
-            this.GB_EMoves.Location = new System.Drawing.Point(129, 253);
+            this.GB_EMoves.Location = new System.Drawing.Point(172, 311);
+            this.GB_EMoves.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.GB_EMoves.Name = "GB_EMoves";
-            this.GB_EMoves.Size = new System.Drawing.Size(133, 112);
+            this.GB_EMoves.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.GB_EMoves.Size = new System.Drawing.Size(177, 138);
             this.GB_EMoves.TabIndex = 17;
             this.GB_EMoves.TabStop = false;
             this.GB_EMoves.Text = "Moves";
             // 
             // CB_EMove3
             // 
+            this.CB_EMove3.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_EMove3.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EMove3.FormattingEnabled = true;
-            this.CB_EMove3.Location = new System.Drawing.Point(6, 85);
+            this.CB_EMove3.Location = new System.Drawing.Point(8, 105);
+            this.CB_EMove3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EMove3.Name = "CB_EMove3";
-            this.CB_EMove3.Size = new System.Drawing.Size(121, 21);
+            this.CB_EMove3.Size = new System.Drawing.Size(160, 24);
             this.CB_EMove3.TabIndex = 20;
             // 
             // CB_EMove2
             // 
+            this.CB_EMove2.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_EMove2.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EMove2.FormattingEnabled = true;
-            this.CB_EMove2.Location = new System.Drawing.Point(6, 63);
+            this.CB_EMove2.Location = new System.Drawing.Point(8, 78);
+            this.CB_EMove2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EMove2.Name = "CB_EMove2";
-            this.CB_EMove2.Size = new System.Drawing.Size(121, 21);
+            this.CB_EMove2.Size = new System.Drawing.Size(160, 24);
             this.CB_EMove2.TabIndex = 19;
             // 
             // CB_EMove1
             // 
+            this.CB_EMove1.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_EMove1.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EMove1.FormattingEnabled = true;
-            this.CB_EMove1.Location = new System.Drawing.Point(6, 41);
+            this.CB_EMove1.Location = new System.Drawing.Point(8, 50);
+            this.CB_EMove1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EMove1.Name = "CB_EMove1";
-            this.CB_EMove1.Size = new System.Drawing.Size(121, 21);
+            this.CB_EMove1.Size = new System.Drawing.Size(160, 24);
             this.CB_EMove1.TabIndex = 18;
             // 
             // CB_EMove0
             // 
+            this.CB_EMove0.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_EMove0.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EMove0.FormattingEnabled = true;
-            this.CB_EMove0.Location = new System.Drawing.Point(6, 19);
+            this.CB_EMove0.Location = new System.Drawing.Point(8, 23);
+            this.CB_EMove0.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EMove0.Name = "CB_EMove0";
-            this.CB_EMove0.Size = new System.Drawing.Size(121, 21);
+            this.CB_EMove0.Size = new System.Drawing.Size(160, 24);
             this.CB_EMove0.TabIndex = 17;
             // 
             // CB_EHeldItem
             // 
+            this.CB_EHeldItem.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_EHeldItem.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_EHeldItem.FormattingEnabled = true;
-            this.CB_EHeldItem.Location = new System.Drawing.Point(187, 115);
+            this.CB_EHeldItem.Location = new System.Drawing.Point(249, 142);
+            this.CB_EHeldItem.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_EHeldItem.Name = "CB_EHeldItem";
-            this.CB_EHeldItem.Size = new System.Drawing.Size(136, 21);
+            this.CB_EHeldItem.Size = new System.Drawing.Size(180, 24);
             this.CB_EHeldItem.TabIndex = 16;
             // 
             // L_EHeldItem
             // 
-            this.L_EHeldItem.Location = new System.Drawing.Point(131, 113);
+            this.L_EHeldItem.Location = new System.Drawing.Point(175, 139);
+            this.L_EHeldItem.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_EHeldItem.Name = "L_EHeldItem";
-            this.L_EHeldItem.Size = new System.Drawing.Size(55, 23);
+            this.L_EHeldItem.Size = new System.Drawing.Size(73, 28);
             this.L_EHeldItem.TabIndex = 15;
             this.L_EHeldItem.Text = "Held Item:";
             this.L_EHeldItem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_ESpecies
             // 
+            this.CB_ESpecies.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_ESpecies.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_ESpecies.FormattingEnabled = true;
-            this.CB_ESpecies.Location = new System.Drawing.Point(187, 7);
+            this.CB_ESpecies.Location = new System.Drawing.Point(249, 9);
+            this.CB_ESpecies.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_ESpecies.Name = "CB_ESpecies";
-            this.CB_ESpecies.Size = new System.Drawing.Size(136, 21);
+            this.CB_ESpecies.Size = new System.Drawing.Size(180, 24);
             this.CB_ESpecies.TabIndex = 14;
             this.CB_ESpecies.SelectedIndexChanged += new System.EventHandler(this.ChangeSpecies);
             // 
             // L_EForm
             // 
-            this.L_EForm.Location = new System.Drawing.Point(131, 47);
+            this.L_EForm.Location = new System.Drawing.Point(175, 58);
+            this.L_EForm.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_EForm.Name = "L_EForm";
-            this.L_EForm.Size = new System.Drawing.Size(55, 23);
+            this.L_EForm.Size = new System.Drawing.Size(73, 28);
             this.L_EForm.TabIndex = 13;
             this.L_EForm.Text = "Form:";
             this.L_EForm.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_EForm
             // 
-            this.NUD_EForm.Location = new System.Drawing.Point(187, 50);
+            this.NUD_EForm.Location = new System.Drawing.Point(249, 62);
+            this.NUD_EForm.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_EForm.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.NUD_EForm.Name = "NUD_EForm";
-            this.NUD_EForm.Size = new System.Drawing.Size(48, 20);
+            this.NUD_EForm.Size = new System.Drawing.Size(64, 22);
             this.NUD_EForm.TabIndex = 12;
             this.NUD_EForm.Value = new decimal(new int[] {
             100,
@@ -1090,27 +1228,30 @@
             // 
             // L_ELevel
             // 
-            this.L_ELevel.Location = new System.Drawing.Point(131, 26);
+            this.L_ELevel.Location = new System.Drawing.Point(175, 32);
+            this.L_ELevel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_ELevel.Name = "L_ELevel";
-            this.L_ELevel.Size = new System.Drawing.Size(55, 23);
+            this.L_ELevel.Size = new System.Drawing.Size(73, 28);
             this.L_ELevel.TabIndex = 11;
             this.L_ELevel.Text = "Level:";
             this.L_ELevel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_ESpecies
             // 
-            this.L_ESpecies.Location = new System.Drawing.Point(131, 5);
+            this.L_ESpecies.Location = new System.Drawing.Point(175, 6);
+            this.L_ESpecies.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_ESpecies.Name = "L_ESpecies";
-            this.L_ESpecies.Size = new System.Drawing.Size(55, 23);
+            this.L_ESpecies.Size = new System.Drawing.Size(73, 28);
             this.L_ESpecies.TabIndex = 10;
             this.L_ESpecies.Text = "Species:";
             this.L_ESpecies.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_ELevel
             // 
-            this.NUD_ELevel.Location = new System.Drawing.Point(187, 29);
+            this.NUD_ELevel.Location = new System.Drawing.Point(249, 36);
+            this.NUD_ELevel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_ELevel.Name = "NUD_ELevel";
-            this.NUD_ELevel.Size = new System.Drawing.Size(48, 20);
+            this.NUD_ELevel.Size = new System.Drawing.Size(64, 22);
             this.NUD_ELevel.TabIndex = 9;
             this.NUD_ELevel.Value = new decimal(new int[] {
             100,
@@ -1123,26 +1264,30 @@
             this.LB_Encounter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.LB_Encounter.FormattingEnabled = true;
-            this.LB_Encounter.Location = new System.Drawing.Point(3, 3);
+            this.LB_Encounter.ItemHeight = 16;
+            this.LB_Encounter.Location = new System.Drawing.Point(4, 4);
+            this.LB_Encounter.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.LB_Encounter.Name = "LB_Encounter";
-            this.LB_Encounter.Size = new System.Drawing.Size(115, 498);
+            this.LB_Encounter.Size = new System.Drawing.Size(152, 612);
             this.LB_Encounter.TabIndex = 1;
             this.LB_Encounter.SelectedIndexChanged += new System.EventHandler(this.LB_Encounter_SelectedIndexChanged);
             // 
             // L_Ally2
             // 
-            this.L_Ally2.Location = new System.Drawing.Point(237, 199);
+            this.L_Ally2.Location = new System.Drawing.Point(316, 245);
+            this.L_Ally2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_Ally2.Name = "L_Ally2";
-            this.L_Ally2.Size = new System.Drawing.Size(135, 23);
+            this.L_Ally2.Size = new System.Drawing.Size(180, 28);
             this.L_Ally2.TabIndex = 525;
             this.L_Ally2.Text = "WWWWWWWWWWWW";
             this.L_Ally2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // L_Ally1
             // 
-            this.L_Ally1.Location = new System.Drawing.Point(237, 179);
+            this.L_Ally1.Location = new System.Drawing.Point(316, 220);
+            this.L_Ally1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_Ally1.Name = "L_Ally1";
-            this.L_Ally1.Size = new System.Drawing.Size(135, 23);
+            this.L_Ally1.Size = new System.Drawing.Size(180, 28);
             this.L_Ally1.TabIndex = 524;
             this.L_Ally1.Text = "WWWWWWWWWWWW";
             this.L_Ally1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -1170,10 +1315,11 @@
             this.Tab_Trades.Controls.Add(this.L_TSpecies);
             this.Tab_Trades.Controls.Add(this.NUD_TLevel);
             this.Tab_Trades.Controls.Add(this.LB_Trade);
-            this.Tab_Trades.Location = new System.Drawing.Point(4, 22);
+            this.Tab_Trades.Location = new System.Drawing.Point(4, 25);
+            this.Tab_Trades.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Tab_Trades.Name = "Tab_Trades";
-            this.Tab_Trades.Padding = new System.Windows.Forms.Padding(3);
-            this.Tab_Trades.Size = new System.Drawing.Size(498, 512);
+            this.Tab_Trades.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Tab_Trades.Size = new System.Drawing.Size(667, 633);
             this.Tab_Trades.TabIndex = 1;
             this.Tab_Trades.Text = "Trades";
             this.Tab_Trades.UseVisualStyleBackColor = true;
@@ -1181,16 +1327,18 @@
             // CB_TGender
             // 
             this.CB_TGender.FormattingEnabled = true;
-            this.CB_TGender.Location = new System.Drawing.Point(187, 71);
+            this.CB_TGender.Location = new System.Drawing.Point(249, 87);
+            this.CB_TGender.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_TGender.Name = "CB_TGender";
-            this.CB_TGender.Size = new System.Drawing.Size(136, 21);
+            this.CB_TGender.Size = new System.Drawing.Size(180, 24);
             this.CB_TGender.TabIndex = 527;
             // 
             // L_TGender
             // 
-            this.L_TGender.Location = new System.Drawing.Point(131, 69);
+            this.L_TGender.Location = new System.Drawing.Point(175, 85);
+            this.L_TGender.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TGender.Name = "L_TGender";
-            this.L_TGender.Size = new System.Drawing.Size(55, 23);
+            this.L_TGender.Size = new System.Drawing.Size(73, 28);
             this.L_TGender.TabIndex = 523;
             this.L_TGender.Text = "Gender:";
             this.L_TGender.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -1198,33 +1346,39 @@
             // CB_TAbility
             // 
             this.CB_TAbility.FormattingEnabled = true;
-            this.CB_TAbility.Location = new System.Drawing.Point(187, 93);
+            this.CB_TAbility.Location = new System.Drawing.Point(249, 114);
+            this.CB_TAbility.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_TAbility.Name = "CB_TAbility";
-            this.CB_TAbility.Size = new System.Drawing.Size(136, 21);
+            this.CB_TAbility.Size = new System.Drawing.Size(180, 24);
             this.CB_TAbility.TabIndex = 521;
             // 
             // L_TAbility
             // 
-            this.L_TAbility.Location = new System.Drawing.Point(131, 91);
+            this.L_TAbility.Location = new System.Drawing.Point(175, 112);
+            this.L_TAbility.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TAbility.Name = "L_TAbility";
-            this.L_TAbility.Size = new System.Drawing.Size(55, 23);
+            this.L_TAbility.Size = new System.Drawing.Size(73, 28);
             this.L_TAbility.TabIndex = 520;
             this.L_TAbility.Text = "Ability:";
             this.L_TAbility.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_TNature
             // 
+            this.CB_TNature.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_TNature.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_TNature.FormattingEnabled = true;
-            this.CB_TNature.Location = new System.Drawing.Point(187, 137);
+            this.CB_TNature.Location = new System.Drawing.Point(249, 169);
+            this.CB_TNature.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_TNature.Name = "CB_TNature";
-            this.CB_TNature.Size = new System.Drawing.Size(136, 21);
+            this.CB_TNature.Size = new System.Drawing.Size(180, 24);
             this.CB_TNature.TabIndex = 505;
             // 
             // L_TNature
             // 
-            this.L_TNature.Location = new System.Drawing.Point(131, 135);
+            this.L_TNature.Location = new System.Drawing.Point(175, 166);
+            this.L_TNature.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TNature.Name = "L_TNature";
-            this.L_TNature.Size = new System.Drawing.Size(55, 23);
+            this.L_TNature.Size = new System.Drawing.Size(73, 28);
             this.L_TNature.TabIndex = 504;
             this.L_TNature.Text = "Nature:";
             this.L_TNature.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -1243,25 +1397,29 @@
             this.groupBox1.Controls.Add(this.NUD_TIV0);
             this.groupBox1.Controls.Add(this.label12);
             this.groupBox1.Controls.Add(this.label13);
-            this.groupBox1.Location = new System.Drawing.Point(129, 222);
+            this.groupBox1.Location = new System.Drawing.Point(172, 273);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(148, 112);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox1.Size = new System.Drawing.Size(197, 138);
             this.groupBox1.TabIndex = 30;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "IVs";
             // 
             // label8
             // 
-            this.label8.Location = new System.Drawing.Point(4, 16);
+            this.label8.Location = new System.Drawing.Point(5, 20);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(29, 21);
+            this.label8.Size = new System.Drawing.Size(39, 26);
             this.label8.TabIndex = 495;
             this.label8.Text = "HP:";
             this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_TIV3
             // 
-            this.NUD_TIV3.Location = new System.Drawing.Point(104, 18);
+            this.NUD_TIV3.Location = new System.Drawing.Point(139, 22);
+            this.NUD_TIV3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV3.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1273,7 +1431,7 @@
             0,
             -2147483648});
             this.NUD_TIV3.Name = "NUD_TIV3";
-            this.NUD_TIV3.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV3.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV3.TabIndex = 492;
             this.NUD_TIV3.Value = new decimal(new int[] {
             31,
@@ -1283,7 +1441,8 @@
             // 
             // NUD_TIV4
             // 
-            this.NUD_TIV4.Location = new System.Drawing.Point(104, 49);
+            this.NUD_TIV4.Location = new System.Drawing.Point(139, 60);
+            this.NUD_TIV4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV4.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1295,7 +1454,7 @@
             0,
             -2147483648});
             this.NUD_TIV4.Name = "NUD_TIV4";
-            this.NUD_TIV4.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV4.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV4.TabIndex = 493;
             this.NUD_TIV4.Value = new decimal(new int[] {
             31,
@@ -1305,7 +1464,8 @@
             // 
             // NUD_TIV5
             // 
-            this.NUD_TIV5.Location = new System.Drawing.Point(104, 80);
+            this.NUD_TIV5.Location = new System.Drawing.Point(139, 98);
+            this.NUD_TIV5.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV5.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1317,7 +1477,7 @@
             0,
             -2147483648});
             this.NUD_TIV5.Name = "NUD_TIV5";
-            this.NUD_TIV5.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV5.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV5.TabIndex = 494;
             this.NUD_TIV5.Value = new decimal(new int[] {
             31,
@@ -1327,34 +1487,38 @@
             // 
             // label9
             // 
-            this.label9.Location = new System.Drawing.Point(73, 47);
+            this.label9.Location = new System.Drawing.Point(97, 58);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(31, 21);
+            this.label9.Size = new System.Drawing.Size(41, 26);
             this.label9.TabIndex = 500;
             this.label9.Text = "SpD:";
             this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label10
             // 
-            this.label10.Location = new System.Drawing.Point(73, 78);
+            this.label10.Location = new System.Drawing.Point(97, 96);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(31, 21);
+            this.label10.Size = new System.Drawing.Size(41, 26);
             this.label10.TabIndex = 499;
             this.label10.Text = "Spe:";
             this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label11
             // 
-            this.label11.Location = new System.Drawing.Point(73, 16);
+            this.label11.Location = new System.Drawing.Point(97, 20);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(31, 21);
+            this.label11.Size = new System.Drawing.Size(41, 26);
             this.label11.TabIndex = 498;
             this.label11.Text = "SpA:";
             this.label11.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_TIV2
             // 
-            this.NUD_TIV2.Location = new System.Drawing.Point(33, 80);
+            this.NUD_TIV2.Location = new System.Drawing.Point(44, 98);
+            this.NUD_TIV2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV2.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1366,7 +1530,7 @@
             0,
             -2147483648});
             this.NUD_TIV2.Name = "NUD_TIV2";
-            this.NUD_TIV2.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV2.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV2.TabIndex = 491;
             this.NUD_TIV2.Value = new decimal(new int[] {
             31,
@@ -1376,7 +1540,8 @@
             // 
             // NUD_TIV1
             // 
-            this.NUD_TIV1.Location = new System.Drawing.Point(33, 49);
+            this.NUD_TIV1.Location = new System.Drawing.Point(44, 60);
+            this.NUD_TIV1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV1.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1388,7 +1553,7 @@
             0,
             -2147483648});
             this.NUD_TIV1.Name = "NUD_TIV1";
-            this.NUD_TIV1.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV1.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV1.TabIndex = 490;
             this.NUD_TIV1.Value = new decimal(new int[] {
             31,
@@ -1398,7 +1563,8 @@
             // 
             // NUD_TIV0
             // 
-            this.NUD_TIV0.Location = new System.Drawing.Point(33, 18);
+            this.NUD_TIV0.Location = new System.Drawing.Point(44, 22);
+            this.NUD_TIV0.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TIV0.Maximum = new decimal(new int[] {
             31,
             0,
@@ -1410,7 +1576,7 @@
             0,
             -2147483648});
             this.NUD_TIV0.Name = "NUD_TIV0";
-            this.NUD_TIV0.Size = new System.Drawing.Size(34, 20);
+            this.NUD_TIV0.Size = new System.Drawing.Size(45, 22);
             this.NUD_TIV0.TabIndex = 489;
             this.NUD_TIV0.Value = new decimal(new int[] {
             31,
@@ -1420,35 +1586,41 @@
             // 
             // label12
             // 
-            this.label12.Location = new System.Drawing.Point(7, 47);
+            this.label12.Location = new System.Drawing.Point(9, 58);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(26, 21);
+            this.label12.Size = new System.Drawing.Size(35, 26);
             this.label12.TabIndex = 496;
             this.label12.Text = "Atk:";
             this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label13
             // 
-            this.label13.Location = new System.Drawing.Point(4, 78);
+            this.label13.Location = new System.Drawing.Point(5, 96);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(29, 21);
+            this.label13.Size = new System.Drawing.Size(39, 26);
             this.label13.TabIndex = 497;
             this.label13.Text = "Def:";
             this.label13.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_TRequest
             // 
+            this.CB_TRequest.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_TRequest.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_TRequest.FormattingEnabled = true;
-            this.CB_TRequest.Location = new System.Drawing.Point(230, 188);
+            this.CB_TRequest.Location = new System.Drawing.Point(307, 231);
+            this.CB_TRequest.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_TRequest.Name = "CB_TRequest";
-            this.CB_TRequest.Size = new System.Drawing.Size(121, 21);
+            this.CB_TRequest.Size = new System.Drawing.Size(160, 24);
             this.CB_TRequest.TabIndex = 29;
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(121, 186);
+            this.label1.Location = new System.Drawing.Point(161, 229);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(106, 23);
+            this.label1.Size = new System.Drawing.Size(141, 28);
             this.label1.TabIndex = 28;
             this.label1.Text = "Requested Species:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -1456,32 +1628,35 @@
             // L_TTID
             // 
             this.L_TTID.AutoSize = true;
-            this.L_TTID.Location = new System.Drawing.Point(252, 162);
+            this.L_TTID.Location = new System.Drawing.Point(336, 199);
+            this.L_TTID.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TTID.Name = "L_TTID";
-            this.L_TTID.Size = new System.Drawing.Size(53, 13);
+            this.L_TTID.Size = new System.Drawing.Size(62, 16);
             this.L_TTID.TabIndex = 27;
             this.L_TTID.Text = "Gen 7 ID:";
             this.L_TTID.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // L_TID
             // 
-            this.L_TID.Location = new System.Drawing.Point(136, 157);
+            this.L_TID.Location = new System.Drawing.Point(181, 193);
+            this.L_TID.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TID.Name = "L_TID";
-            this.L_TID.Size = new System.Drawing.Size(50, 23);
+            this.L_TID.Size = new System.Drawing.Size(67, 28);
             this.L_TID.TabIndex = 26;
             this.L_TID.Text = "ID:";
             this.L_TID.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_TID
             // 
-            this.NUD_TID.Location = new System.Drawing.Point(187, 159);
+            this.NUD_TID.Location = new System.Drawing.Point(249, 196);
+            this.NUD_TID.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TID.Maximum = new decimal(new int[] {
             999999,
             0,
             0,
             0});
             this.NUD_TID.Name = "NUD_TID";
-            this.NUD_TID.Size = new System.Drawing.Size(60, 20);
+            this.NUD_TID.Size = new System.Drawing.Size(80, 22);
             this.NUD_TID.TabIndex = 25;
             this.NUD_TID.Value = new decimal(new int[] {
             999999,
@@ -1492,49 +1667,58 @@
             // 
             // CB_THeldItem
             // 
+            this.CB_THeldItem.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_THeldItem.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_THeldItem.FormattingEnabled = true;
-            this.CB_THeldItem.Location = new System.Drawing.Point(187, 115);
+            this.CB_THeldItem.Location = new System.Drawing.Point(249, 142);
+            this.CB_THeldItem.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_THeldItem.Name = "CB_THeldItem";
-            this.CB_THeldItem.Size = new System.Drawing.Size(136, 21);
+            this.CB_THeldItem.Size = new System.Drawing.Size(180, 24);
             this.CB_THeldItem.TabIndex = 24;
             // 
             // L_THeldItem
             // 
-            this.L_THeldItem.Location = new System.Drawing.Point(131, 113);
+            this.L_THeldItem.Location = new System.Drawing.Point(175, 139);
+            this.L_THeldItem.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_THeldItem.Name = "L_THeldItem";
-            this.L_THeldItem.Size = new System.Drawing.Size(55, 23);
+            this.L_THeldItem.Size = new System.Drawing.Size(73, 28);
             this.L_THeldItem.TabIndex = 23;
             this.L_THeldItem.Text = "Held Item:";
             this.L_THeldItem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // CB_TSpecies
             // 
+            this.CB_TSpecies.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.CB_TSpecies.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_TSpecies.FormattingEnabled = true;
-            this.CB_TSpecies.Location = new System.Drawing.Point(187, 7);
+            this.CB_TSpecies.Location = new System.Drawing.Point(249, 9);
+            this.CB_TSpecies.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CB_TSpecies.Name = "CB_TSpecies";
-            this.CB_TSpecies.Size = new System.Drawing.Size(136, 21);
+            this.CB_TSpecies.Size = new System.Drawing.Size(180, 24);
             this.CB_TSpecies.TabIndex = 22;
             this.CB_TSpecies.SelectedIndexChanged += new System.EventHandler(this.ChangeSpecies);
             // 
             // L_TForm
             // 
-            this.L_TForm.Location = new System.Drawing.Point(131, 47);
+            this.L_TForm.Location = new System.Drawing.Point(175, 58);
+            this.L_TForm.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TForm.Name = "L_TForm";
-            this.L_TForm.Size = new System.Drawing.Size(55, 23);
+            this.L_TForm.Size = new System.Drawing.Size(73, 28);
             this.L_TForm.TabIndex = 21;
             this.L_TForm.Text = "Form:";
             this.L_TForm.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_TForm
             // 
-            this.NUD_TForm.Location = new System.Drawing.Point(187, 50);
+            this.NUD_TForm.Location = new System.Drawing.Point(249, 62);
+            this.NUD_TForm.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TForm.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.NUD_TForm.Name = "NUD_TForm";
-            this.NUD_TForm.Size = new System.Drawing.Size(48, 20);
+            this.NUD_TForm.Size = new System.Drawing.Size(64, 22);
             this.NUD_TForm.TabIndex = 20;
             this.NUD_TForm.Value = new decimal(new int[] {
             100,
@@ -1544,27 +1728,30 @@
             // 
             // L_TLevel
             // 
-            this.L_TLevel.Location = new System.Drawing.Point(131, 26);
+            this.L_TLevel.Location = new System.Drawing.Point(175, 32);
+            this.L_TLevel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TLevel.Name = "L_TLevel";
-            this.L_TLevel.Size = new System.Drawing.Size(55, 23);
+            this.L_TLevel.Size = new System.Drawing.Size(73, 28);
             this.L_TLevel.TabIndex = 19;
             this.L_TLevel.Text = "Level:";
             this.L_TLevel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_TSpecies
             // 
-            this.L_TSpecies.Location = new System.Drawing.Point(131, 5);
+            this.L_TSpecies.Location = new System.Drawing.Point(175, 6);
+            this.L_TSpecies.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.L_TSpecies.Name = "L_TSpecies";
-            this.L_TSpecies.Size = new System.Drawing.Size(55, 23);
+            this.L_TSpecies.Size = new System.Drawing.Size(73, 28);
             this.L_TSpecies.TabIndex = 18;
             this.L_TSpecies.Text = "Species:";
             this.L_TSpecies.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_TLevel
             // 
-            this.NUD_TLevel.Location = new System.Drawing.Point(187, 29);
+            this.NUD_TLevel.Location = new System.Drawing.Point(249, 36);
+            this.NUD_TLevel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_TLevel.Name = "NUD_TLevel";
-            this.NUD_TLevel.Size = new System.Drawing.Size(48, 20);
+            this.NUD_TLevel.Size = new System.Drawing.Size(64, 22);
             this.NUD_TLevel.TabIndex = 17;
             this.NUD_TLevel.Value = new decimal(new int[] {
             100,
@@ -1577,9 +1764,11 @@
             this.LB_Trade.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.LB_Trade.FormattingEnabled = true;
-            this.LB_Trade.Location = new System.Drawing.Point(3, 3);
+            this.LB_Trade.ItemHeight = 16;
+            this.LB_Trade.Location = new System.Drawing.Point(4, 4);
+            this.LB_Trade.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.LB_Trade.Name = "LB_Trade";
-            this.LB_Trade.Size = new System.Drawing.Size(115, 498);
+            this.LB_Trade.Size = new System.Drawing.Size(152, 612);
             this.LB_Trade.TabIndex = 2;
             this.LB_Trade.SelectedIndexChanged += new System.EventHandler(this.LB_Trade_SelectedIndexChanged);
             // 
@@ -1592,10 +1781,11 @@
             this.Tab_Randomizer.Controls.Add(this.B_RandAll);
             this.Tab_Randomizer.Controls.Add(this.GB_Rand);
             this.Tab_Randomizer.Controls.Add(this.B_Starters);
-            this.Tab_Randomizer.Location = new System.Drawing.Point(4, 22);
+            this.Tab_Randomizer.Location = new System.Drawing.Point(4, 25);
+            this.Tab_Randomizer.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Tab_Randomizer.Name = "Tab_Randomizer";
-            this.Tab_Randomizer.Padding = new System.Windows.Forms.Padding(3);
-            this.Tab_Randomizer.Size = new System.Drawing.Size(498, 512);
+            this.Tab_Randomizer.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Tab_Randomizer.Size = new System.Drawing.Size(667, 633);
             this.Tab_Randomizer.TabIndex = 3;
             this.Tab_Randomizer.Text = "Randomizer Options";
             this.Tab_Randomizer.UseVisualStyleBackColor = true;
@@ -1609,9 +1799,11 @@
             this.GB_Tweak.Controls.Add(this.CHK_ForceFullyEvolved);
             this.GB_Tweak.Controls.Add(this.CHK_BasicStarter);
             this.GB_Tweak.Controls.Add(this.CHK_ReplaceLegend);
-            this.GB_Tweak.Location = new System.Drawing.Point(119, 245);
+            this.GB_Tweak.Location = new System.Drawing.Point(159, 302);
+            this.GB_Tweak.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.GB_Tweak.Name = "GB_Tweak";
-            this.GB_Tweak.Size = new System.Drawing.Size(258, 115);
+            this.GB_Tweak.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.GB_Tweak.Size = new System.Drawing.Size(344, 142);
             this.GB_Tweak.TabIndex = 509;
             this.GB_Tweak.TabStop = false;
             this.GB_Tweak.Text = "Extra Tweaks";
@@ -1619,9 +1811,10 @@
             // CHK_Metronome
             // 
             this.CHK_Metronome.AutoSize = true;
-            this.CHK_Metronome.Location = new System.Drawing.Point(6, 95);
+            this.CHK_Metronome.Location = new System.Drawing.Point(8, 117);
+            this.CHK_Metronome.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_Metronome.Name = "CHK_Metronome";
-            this.CHK_Metronome.Size = new System.Drawing.Size(109, 17);
+            this.CHK_Metronome.Size = new System.Drawing.Size(133, 20);
             this.CHK_Metronome.TabIndex = 515;
             this.CHK_Metronome.Text = "Metronome Mode";
             this.CHK_Metronome.UseVisualStyleBackColor = true;
@@ -1631,23 +1824,25 @@
             this.CHK_RemoveShinyLock.AutoSize = true;
             this.CHK_RemoveShinyLock.Checked = true;
             this.CHK_RemoveShinyLock.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_RemoveShinyLock.Location = new System.Drawing.Point(6, 79);
+            this.CHK_RemoveShinyLock.Location = new System.Drawing.Point(8, 97);
+            this.CHK_RemoveShinyLock.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_RemoveShinyLock.Name = "CHK_RemoveShinyLock";
-            this.CHK_RemoveShinyLock.Size = new System.Drawing.Size(127, 17);
+            this.CHK_RemoveShinyLock.Size = new System.Drawing.Size(154, 20);
             this.CHK_RemoveShinyLock.TabIndex = 299;
             this.CHK_RemoveShinyLock.Text = "Remove Shiny Locks";
             this.CHK_RemoveShinyLock.UseVisualStyleBackColor = true;
             // 
             // NUD_ForceFullyEvolved
             // 
-            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(165, 62);
+            this.NUD_ForceFullyEvolved.Location = new System.Drawing.Point(220, 76);
+            this.NUD_ForceFullyEvolved.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_ForceFullyEvolved.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.NUD_ForceFullyEvolved.Name = "NUD_ForceFullyEvolved";
-            this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(40, 20);
+            this.NUD_ForceFullyEvolved.Size = new System.Drawing.Size(53, 22);
             this.NUD_ForceFullyEvolved.TabIndex = 514;
             this.NUD_ForceFullyEvolved.Value = new decimal(new int[] {
             50,
@@ -1658,9 +1853,10 @@
             // CHK_ForceTotem
             // 
             this.CHK_ForceTotem.AutoSize = true;
-            this.CHK_ForceTotem.Location = new System.Drawing.Point(6, 47);
+            this.CHK_ForceTotem.Location = new System.Drawing.Point(8, 58);
+            this.CHK_ForceTotem.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_ForceTotem.Name = "CHK_ForceTotem";
-            this.CHK_ForceTotem.Size = new System.Drawing.Size(200, 17);
+            this.CHK_ForceTotem.Size = new System.Drawing.Size(249, 20);
             this.CHK_ForceTotem.TabIndex = 305;
             this.CHK_ForceTotem.Text = "Force Fully Evolved Totem Pokémon";
             this.CHK_ForceTotem.UseVisualStyleBackColor = true;
@@ -1669,9 +1865,10 @@
             // 
             this.CHK_ForceFullyEvolved.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.CHK_ForceFullyEvolved.AutoSize = true;
-            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(6, 63);
+            this.CHK_ForceFullyEvolved.Location = new System.Drawing.Point(8, 80);
+            this.CHK_ForceFullyEvolved.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_ForceFullyEvolved.Name = "CHK_ForceFullyEvolved";
-            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(160, 17);
+            this.CHK_ForceFullyEvolved.Size = new System.Drawing.Size(196, 20);
             this.CHK_ForceFullyEvolved.TabIndex = 513;
             this.CHK_ForceFullyEvolved.Text = "Force Fully Evolved at Level";
             this.CHK_ForceFullyEvolved.UseVisualStyleBackColor = true;
@@ -1681,9 +1878,10 @@
             this.CHK_BasicStarter.AutoSize = true;
             this.CHK_BasicStarter.Checked = true;
             this.CHK_BasicStarter.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_BasicStarter.Location = new System.Drawing.Point(6, 31);
+            this.CHK_BasicStarter.Location = new System.Drawing.Point(8, 38);
+            this.CHK_BasicStarter.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_BasicStarter.Name = "CHK_BasicStarter";
-            this.CHK_BasicStarter.Size = new System.Drawing.Size(217, 17);
+            this.CHK_BasicStarter.Size = new System.Drawing.Size(264, 20);
             this.CHK_BasicStarter.TabIndex = 304;
             this.CHK_BasicStarter.Text = "Basic Starter Pokémon with 2 Evolutions";
             this.CHK_BasicStarter.UseVisualStyleBackColor = true;
@@ -1693,18 +1891,20 @@
             this.CHK_ReplaceLegend.AutoSize = true;
             this.CHK_ReplaceLegend.Checked = true;
             this.CHK_ReplaceLegend.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_ReplaceLegend.Location = new System.Drawing.Point(6, 15);
+            this.CHK_ReplaceLegend.Location = new System.Drawing.Point(8, 18);
+            this.CHK_ReplaceLegend.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_ReplaceLegend.Name = "CHK_ReplaceLegend";
-            this.CHK_ReplaceLegend.Size = new System.Drawing.Size(242, 17);
+            this.CHK_ReplaceLegend.Size = new System.Drawing.Size(300, 20);
             this.CHK_ReplaceLegend.TabIndex = 303;
             this.CHK_ReplaceLegend.Text = "Replace Legendaries with Another Legendary";
             this.CHK_ReplaceLegend.UseVisualStyleBackColor = true;
             // 
             // B_ModifyLevel
             // 
-            this.B_ModifyLevel.Location = new System.Drawing.Point(306, 49);
+            this.B_ModifyLevel.Location = new System.Drawing.Point(408, 60);
+            this.B_ModifyLevel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_ModifyLevel.Name = "B_ModifyLevel";
-            this.B_ModifyLevel.Size = new System.Drawing.Size(70, 23);
+            this.B_ModifyLevel.Size = new System.Drawing.Size(93, 28);
             this.B_ModifyLevel.TabIndex = 512;
             this.B_ModifyLevel.Text = "× Current";
             this.B_ModifyLevel.UseVisualStyleBackColor = true;
@@ -1718,14 +1918,15 @@
             0,
             0,
             131072});
-            this.NUD_LevelBoost.Location = new System.Drawing.Point(257, 50);
+            this.NUD_LevelBoost.Location = new System.Drawing.Point(343, 62);
+            this.NUD_LevelBoost.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NUD_LevelBoost.Maximum = new decimal(new int[] {
             3,
             0,
             0,
             0});
             this.NUD_LevelBoost.Name = "NUD_LevelBoost";
-            this.NUD_LevelBoost.Size = new System.Drawing.Size(43, 20);
+            this.NUD_LevelBoost.Size = new System.Drawing.Size(57, 22);
             this.NUD_LevelBoost.TabIndex = 511;
             this.NUD_LevelBoost.Value = new decimal(new int[] {
             1,
@@ -1738,18 +1939,20 @@
             this.CHK_Level.AutoSize = true;
             this.CHK_Level.Checked = true;
             this.CHK_Level.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Level.Location = new System.Drawing.Point(125, 51);
+            this.CHK_Level.Location = new System.Drawing.Point(167, 63);
+            this.CHK_Level.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_Level.Name = "CHK_Level";
-            this.CHK_Level.Size = new System.Drawing.Size(130, 17);
+            this.CHK_Level.Size = new System.Drawing.Size(157, 20);
             this.CHK_Level.TabIndex = 510;
             this.CHK_Level.Text = "Multiply PKM Level by";
             this.CHK_Level.UseVisualStyleBackColor = true;
             // 
             // B_RandAll
             // 
-            this.B_RandAll.Location = new System.Drawing.Point(192, 369);
+            this.B_RandAll.Location = new System.Drawing.Point(256, 454);
+            this.B_RandAll.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_RandAll.Name = "B_RandAll";
-            this.B_RandAll.Size = new System.Drawing.Size(122, 23);
+            this.B_RandAll.Size = new System.Drawing.Size(163, 28);
             this.B_RandAll.TabIndex = 509;
             this.B_RandAll.Text = "Randomize All";
             this.B_RandAll.UseVisualStyleBackColor = true;
@@ -1772,9 +1975,11 @@
             this.GB_Rand.Controls.Add(this.CHK_G3);
             this.GB_Rand.Controls.Add(this.CHK_G2);
             this.GB_Rand.Controls.Add(this.CHK_G1);
-            this.GB_Rand.Location = new System.Drawing.Point(119, 73);
+            this.GB_Rand.Location = new System.Drawing.Point(159, 90);
+            this.GB_Rand.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.GB_Rand.Name = "GB_Rand";
-            this.GB_Rand.Size = new System.Drawing.Size(258, 155);
+            this.GB_Rand.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.GB_Rand.Size = new System.Drawing.Size(344, 191);
             this.GB_Rand.TabIndex = 508;
             this.GB_Rand.TabStop = false;
             this.GB_Rand.Text = "Randomizer Options";
@@ -1782,9 +1987,10 @@
             // CHK_SpecialMove
             // 
             this.CHK_SpecialMove.AutoSize = true;
-            this.CHK_SpecialMove.Location = new System.Drawing.Point(9, 135);
+            this.CHK_SpecialMove.Location = new System.Drawing.Point(12, 166);
+            this.CHK_SpecialMove.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_SpecialMove.Name = "CHK_SpecialMove";
-            this.CHK_SpecialMove.Size = new System.Drawing.Size(197, 17);
+            this.CHK_SpecialMove.Size = new System.Drawing.Size(239, 20);
             this.CHK_SpecialMove.TabIndex = 301;
             this.CHK_SpecialMove.Text = "Random Gift Move for Gift Pokémon";
             this.CHK_SpecialMove.UseVisualStyleBackColor = true;
@@ -1792,9 +1998,10 @@
             // CHK_RandomAbility
             // 
             this.CHK_RandomAbility.AutoSize = true;
-            this.CHK_RandomAbility.Location = new System.Drawing.Point(9, 120);
+            this.CHK_RandomAbility.Location = new System.Drawing.Point(12, 148);
+            this.CHK_RandomAbility.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_RandomAbility.Name = "CHK_RandomAbility";
-            this.CHK_RandomAbility.Size = new System.Drawing.Size(183, 17);
+            this.CHK_RandomAbility.Size = new System.Drawing.Size(225, 20);
             this.CHK_RandomAbility.TabIndex = 302;
             this.CHK_RandomAbility.Text = "Random Abilities (1, 2, or Hidden)";
             this.CHK_RandomAbility.UseVisualStyleBackColor = true;
@@ -1802,9 +2009,10 @@
             // CHK_RandomAura
             // 
             this.CHK_RandomAura.AutoSize = true;
-            this.CHK_RandomAura.Location = new System.Drawing.Point(9, 105);
+            this.CHK_RandomAura.Location = new System.Drawing.Point(12, 129);
+            this.CHK_RandomAura.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_RandomAura.Name = "CHK_RandomAura";
-            this.CHK_RandomAura.Size = new System.Drawing.Size(172, 17);
+            this.CHK_RandomAura.Size = new System.Drawing.Size(213, 20);
             this.CHK_RandomAura.TabIndex = 300;
             this.CHK_RandomAura.Text = "Random Totem Pokémon Aura";
             this.CHK_RandomAura.UseVisualStyleBackColor = true;
@@ -1812,9 +2020,10 @@
             // CHK_AllowMega
             // 
             this.CHK_AllowMega.AutoSize = true;
-            this.CHK_AllowMega.Location = new System.Drawing.Point(9, 90);
+            this.CHK_AllowMega.Location = new System.Drawing.Point(12, 111);
+            this.CHK_AllowMega.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_AllowMega.Name = "CHK_AllowMega";
-            this.CHK_AllowMega.Size = new System.Drawing.Size(155, 17);
+            this.CHK_AllowMega.Size = new System.Drawing.Size(193, 20);
             this.CHK_AllowMega.TabIndex = 298;
             this.CHK_AllowMega.Text = "Allow Random Mega Forms";
             this.CHK_AllowMega.UseVisualStyleBackColor = true;
@@ -1824,9 +2033,10 @@
             this.CHK_Item.AutoSize = true;
             this.CHK_Item.Checked = true;
             this.CHK_Item.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_Item.Location = new System.Drawing.Point(9, 75);
+            this.CHK_Item.Location = new System.Drawing.Point(12, 92);
+            this.CHK_Item.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_Item.Name = "CHK_Item";
-            this.CHK_Item.Size = new System.Drawing.Size(119, 17);
+            this.CHK_Item.Size = new System.Drawing.Size(146, 20);
             this.CHK_Item.TabIndex = 297;
             this.CHK_Item.Text = "Random Held Items";
             this.CHK_Item.UseVisualStyleBackColor = true;
@@ -1836,9 +2046,10 @@
             this.CHK_G7.AutoSize = true;
             this.CHK_G7.Checked = true;
             this.CHK_G7.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G7.Location = new System.Drawing.Point(9, 57);
+            this.CHK_G7.Location = new System.Drawing.Point(12, 70);
+            this.CHK_G7.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G7.Name = "CHK_G7";
-            this.CHK_G7.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G7.Size = new System.Drawing.Size(62, 20);
             this.CHK_G7.TabIndex = 296;
             this.CHK_G7.Text = "Gen 7";
             this.CHK_G7.UseVisualStyleBackColor = true;
@@ -1846,9 +2057,10 @@
             // CHK_BST
             // 
             this.CHK_BST.AutoSize = true;
-            this.CHK_BST.Location = new System.Drawing.Point(128, 43);
+            this.CHK_BST.Location = new System.Drawing.Point(171, 53);
+            this.CHK_BST.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_BST.Name = "CHK_BST";
-            this.CHK_BST.Size = new System.Drawing.Size(117, 17);
+            this.CHK_BST.Size = new System.Drawing.Size(144, 20);
             this.CHK_BST.TabIndex = 288;
             this.CHK_BST.Text = "Randomize by BST";
             this.CHK_BST.UseVisualStyleBackColor = true;
@@ -1858,9 +2070,10 @@
             this.CHK_E.AutoSize = true;
             this.CHK_E.Checked = true;
             this.CHK_E.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_E.Location = new System.Drawing.Point(128, 29);
+            this.CHK_E.Location = new System.Drawing.Point(171, 36);
+            this.CHK_E.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_E.Name = "CHK_E";
-            this.CHK_E.Size = new System.Drawing.Size(98, 17);
+            this.CHK_E.Size = new System.Drawing.Size(117, 20);
             this.CHK_E.TabIndex = 287;
             this.CHK_E.Text = "Event Legends";
             this.CHK_E.UseVisualStyleBackColor = true;
@@ -1870,9 +2083,10 @@
             this.CHK_L.AutoSize = true;
             this.CHK_L.Checked = true;
             this.CHK_L.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_L.Location = new System.Drawing.Point(128, 15);
+            this.CHK_L.Location = new System.Drawing.Point(171, 18);
+            this.CHK_L.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_L.Name = "CHK_L";
-            this.CHK_L.Size = new System.Drawing.Size(98, 17);
+            this.CHK_L.Size = new System.Drawing.Size(120, 20);
             this.CHK_L.TabIndex = 286;
             this.CHK_L.Text = "Game Legends";
             this.CHK_L.UseVisualStyleBackColor = true;
@@ -1882,9 +2096,10 @@
             this.CHK_G6.AutoSize = true;
             this.CHK_G6.Checked = true;
             this.CHK_G6.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G6.Location = new System.Drawing.Point(67, 43);
+            this.CHK_G6.Location = new System.Drawing.Point(89, 53);
+            this.CHK_G6.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G6.Name = "CHK_G6";
-            this.CHK_G6.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G6.Size = new System.Drawing.Size(62, 20);
             this.CHK_G6.TabIndex = 285;
             this.CHK_G6.Text = "Gen 6";
             this.CHK_G6.UseVisualStyleBackColor = true;
@@ -1894,9 +2109,10 @@
             this.CHK_G5.AutoSize = true;
             this.CHK_G5.Checked = true;
             this.CHK_G5.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G5.Location = new System.Drawing.Point(67, 29);
+            this.CHK_G5.Location = new System.Drawing.Point(89, 36);
+            this.CHK_G5.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G5.Name = "CHK_G5";
-            this.CHK_G5.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G5.Size = new System.Drawing.Size(62, 20);
             this.CHK_G5.TabIndex = 284;
             this.CHK_G5.Text = "Gen 5";
             this.CHK_G5.UseVisualStyleBackColor = true;
@@ -1906,9 +2122,10 @@
             this.CHK_G4.AutoSize = true;
             this.CHK_G4.Checked = true;
             this.CHK_G4.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G4.Location = new System.Drawing.Point(67, 15);
+            this.CHK_G4.Location = new System.Drawing.Point(89, 18);
+            this.CHK_G4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G4.Name = "CHK_G4";
-            this.CHK_G4.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G4.Size = new System.Drawing.Size(62, 20);
             this.CHK_G4.TabIndex = 283;
             this.CHK_G4.Text = "Gen 4";
             this.CHK_G4.UseVisualStyleBackColor = true;
@@ -1918,9 +2135,10 @@
             this.CHK_G3.AutoSize = true;
             this.CHK_G3.Checked = true;
             this.CHK_G3.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G3.Location = new System.Drawing.Point(9, 43);
+            this.CHK_G3.Location = new System.Drawing.Point(12, 53);
+            this.CHK_G3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G3.Name = "CHK_G3";
-            this.CHK_G3.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G3.Size = new System.Drawing.Size(62, 20);
             this.CHK_G3.TabIndex = 282;
             this.CHK_G3.Text = "Gen 3";
             this.CHK_G3.UseVisualStyleBackColor = true;
@@ -1930,9 +2148,10 @@
             this.CHK_G2.AutoSize = true;
             this.CHK_G2.Checked = true;
             this.CHK_G2.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G2.Location = new System.Drawing.Point(9, 29);
+            this.CHK_G2.Location = new System.Drawing.Point(12, 36);
+            this.CHK_G2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G2.Name = "CHK_G2";
-            this.CHK_G2.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G2.Size = new System.Drawing.Size(62, 20);
             this.CHK_G2.TabIndex = 281;
             this.CHK_G2.Text = "Gen 2";
             this.CHK_G2.UseVisualStyleBackColor = true;
@@ -1942,18 +2161,20 @@
             this.CHK_G1.AutoSize = true;
             this.CHK_G1.Checked = true;
             this.CHK_G1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CHK_G1.Location = new System.Drawing.Point(9, 15);
+            this.CHK_G1.Location = new System.Drawing.Point(12, 18);
+            this.CHK_G1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.CHK_G1.Name = "CHK_G1";
-            this.CHK_G1.Size = new System.Drawing.Size(55, 17);
+            this.CHK_G1.Size = new System.Drawing.Size(62, 20);
             this.CHK_G1.TabIndex = 280;
             this.CHK_G1.Text = "Gen 1";
             this.CHK_G1.UseVisualStyleBackColor = true;
             // 
             // B_Starters
             // 
-            this.B_Starters.Location = new System.Drawing.Point(192, 398);
+            this.B_Starters.Location = new System.Drawing.Point(256, 490);
+            this.B_Starters.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_Starters.Name = "B_Starters";
-            this.B_Starters.Size = new System.Drawing.Size(122, 23);
+            this.B_Starters.Size = new System.Drawing.Size(163, 28);
             this.B_Starters.TabIndex = 9;
             this.B_Starters.Text = "Randomize Starters";
             this.B_Starters.UseVisualStyleBackColor = true;
@@ -1961,9 +2182,10 @@
             // 
             // B_Save
             // 
-            this.B_Save.Location = new System.Drawing.Point(435, 518);
+            this.B_Save.Location = new System.Drawing.Point(580, 638);
+            this.B_Save.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_Save.Name = "B_Save";
-            this.B_Save.Size = new System.Drawing.Size(75, 23);
+            this.B_Save.Size = new System.Drawing.Size(100, 28);
             this.B_Save.TabIndex = 1;
             this.B_Save.Text = "Save";
             this.B_Save.UseVisualStyleBackColor = true;
@@ -1971,9 +2193,10 @@
             // 
             // B_Cancel
             // 
-            this.B_Cancel.Location = new System.Drawing.Point(354, 518);
+            this.B_Cancel.Location = new System.Drawing.Point(472, 638);
+            this.B_Cancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.B_Cancel.Name = "B_Cancel";
-            this.B_Cancel.Size = new System.Drawing.Size(75, 23);
+            this.B_Cancel.Size = new System.Drawing.Size(100, 28);
             this.B_Cancel.TabIndex = 2;
             this.B_Cancel.Text = "Cancel";
             this.B_Cancel.UseVisualStyleBackColor = true;
@@ -1981,12 +2204,13 @@
             // 
             // StaticEncounterEditor7
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(530, 571);
+            this.ClientSize = new System.Drawing.Size(707, 703);
             this.Controls.Add(this.B_Cancel);
             this.Controls.Add(this.B_Save);
             this.Controls.Add(this.TC_Tabs);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "StaticEncounterEditor7";
             this.Text = "StaticEncounterEditor7";
             this.TC_Tabs.ResumeLayout(false);
@@ -2184,5 +2408,8 @@
         private System.Windows.Forms.Label L_Ally1;
         private System.Windows.Forms.ComboBox CB_EGender;
         private System.Windows.Forms.ComboBox CB_TGender;
+        private System.Windows.Forms.Button B_ClearSE;
+        private System.Windows.Forms.Button B_CurrentAttackSE;
+        private System.Windows.Forms.Button B_HighAttackSE;
     }
 }

--- a/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
+++ b/pk3DS/Subforms/Gen7/StaticEncounterEditor7.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 
 using pk3DS.Core;
 using pk3DS.Core.Randomizers;
 using pk3DS.Core.Structures;
+using pk3DS.Core.Structures.PersonalInfo;
 
 namespace pk3DS
 {
@@ -14,6 +16,7 @@ namespace pk3DS
         private readonly EncounterGift7[] Gifts;
         private readonly EncounterStatic7[] Encounters;
         private readonly EncounterTrade7[] Trades;
+        private readonly LearnsetRandomizer learn = new LearnsetRandomizer(Main.Config, Main.Config.Learnsets);
         private readonly string[] movelist = Main.Config.getText(TextName.MoveNames);
         private readonly string[] itemlist = Main.Config.getText(TextName.ItemNames);
         private readonly string[] specieslist = Main.Config.getText(TextName.SpeciesNames);
@@ -80,7 +83,7 @@ namespace pk3DS
                 {
                     byte[] entry = new byte[EncounterGift7.SIZE];
                     Array.Copy(data, i, entry, 0, entry.Length);
-                    Gifts[i/EncounterGift7.SIZE] = new EncounterGift7(entry);
+                    Gifts[i / EncounterGift7.SIZE] = new EncounterGift7(entry);
                 }
             }
             oldStarters = Gifts.Take(3).Select(gift => gift.Species).ToArray();
@@ -93,7 +96,7 @@ namespace pk3DS
                 {
                     byte[] entry = new byte[EncounterStatic7.SIZE];
                     Array.Copy(data, i, entry, 0, entry.Length);
-                    Encounters[i/EncounterStatic7.SIZE] = new EncounterStatic7(entry);
+                    Encounters[i / EncounterStatic7.SIZE] = new EncounterStatic7(entry);
                 }
             }
 
@@ -105,7 +108,7 @@ namespace pk3DS
                 {
                     byte[] entry = new byte[EncounterTrade7.SIZE];
                     Array.Copy(data, i, entry, 0, entry.Length);
-                    Trades[i/EncounterTrade7.SIZE] = new EncounterTrade7(entry);
+                    Trades[i / EncounterTrade7.SIZE] = new EncounterTrade7(entry);
                 }
             }
 
@@ -555,7 +558,7 @@ namespace pk3DS
                 {
                     int rv;
                     do { rv = Util.rand.Next(1, CB_SpecialMove.Items.Count); }
-                    while (banned.Contains(rv)) ;
+                    while (banned.Contains(rv));
                     t.SpecialMove = rv;
                 }
 
@@ -795,5 +798,32 @@ namespace pk3DS
             }
             WinFormsUtil.Alert("Modified all Levels according to specification!");
         }
+
+        private void B_CurrentAttackSE_Click(object sender, EventArgs e)
+        {
+            int species = CB_ESpecies.SelectedIndex;
+            int lvl = (int)NUD_ELevel.Value;
+            int frm = (int)NUD_EForm.Value;
+            int[] moves = learn.GetCurrentMoves(species, frm, lvl, 4);
+            SetMoves(moves);
+        }
+
+        private void B_HighAttackSE_Click(object sender, EventArgs e)
+        {
+            int species = CB_ESpecies.SelectedIndex;
+            int frm = (int)NUD_EForm.Value;
+            int[] moves = learn.GetHighPoweredMoves(species, frm, 4);
+            SetMoves(moves);
+        }
+
+        private void B_ClearSE_Click(object sender, EventArgs e) => SetMoves(new int[4]);
+
+        private void SetMoves(IList<int> moves)
+        {
+            var mcb = new[] { CB_EMove0, CB_EMove1, CB_EMove2, CB_EMove3 };
+            for (int i = 0; i < mcb.Length; i++)
+                mcb[i].SelectedIndex = moves[i];
+        }
+
     }
 }


### PR DESCRIPTION
This PR aims to basically do the same as their counterparts on SMTE, but in StaticEncounter. I found interesting to have this option if someone's (like myself) doing some custom changes from time to time for a nuzlocke or something like that, to avoid looking for the proper moves on the table/exported .txt everytime.  

![image](https://user-images.githubusercontent.com/5099644/66432962-8b17f680-ea1f-11e9-9f20-21e1edc85fe7.png)

I also applied some Autocomplete properties on most of the StaticEncounter listitem fields to avoid unnecessary breakings (like not typing properly a Move/Item/whatever and then saving).

Apologies if the changes seem TOO big, since Visual Studio 2019 Community [changes some properties](https://stackoverflow.com/questions/37109772/why-does-visual-studio-automatically-changes-the-layout-of-my-form) (I had to change my DPI scale back to 100% as some people suggested, but seems like VS still applied those automatic changes).

I also believe this could have been BETTER, apologies for it.

Thanks for your time!