### PR TITLE
Fixed logic for Type Themed Trainers.

### DIFF
--- a/pk3DS/Subforms/Gen6/RSTE.cs
+++ b/pk3DS/Subforms/Gen6/RSTE.cs
@@ -547,7 +547,9 @@ namespace pk3DS
                 // Trainer Type/Mega Evo
                 int type = GetRandomType(i);
                 bool mevo = rEnsureMEvo.Contains(i);
-                bool typerand = (rTypeTheme && !rGymE4Only) || (rTypeTheme && rImportant[i] != null && ImportantClasses.Contains(rImportant[i]));
+                bool isImportantClass = rImportant[i] != null && (rImportant[i].Contains("GYM") || rImportant[i].Contains("ELITE") || rImportant[i].Contains("CHAMPION"));
+                bool typerand = (rTypeTheme && !rGymE4Only) || (rTypeTheme && isImportantClass);
+
                 rSpeciesRand.rType = typerand;
 
                 byte[] trd = trdata[i];


### PR DESCRIPTION
The logic failed to properly detect "GYM6" as a GYM trainer that needed to have Type themed Pokemon. Same for ELITE trainers.

Type themed trainers still sometimes have non-typed Pokemon. I plan to continue looking into this.

Also want to reduce duplicate Pokemon because it seems to be happening very often.