### PR TITLE
XY: Add Snorlax to the Static Encounter editor

### DIFF
--- a/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
+++ b/pk3DS/Subforms/Gen6/StaticEncounterEditor6.cs
@@ -37,9 +37,9 @@ namespace pk3DS
 
         private readonly string FieldPath = Path.Combine(Main.RomFSPath, "DllField.cro");
         private byte[] FieldData;
-        private readonly int fieldOffset = Main.Config.ORAS ? 0xF1B20 : 0xEE478;
+        private readonly int fieldOffset = Main.Config.ORAS ? 0xF1B20 : 0xEE46C;
         private const int fieldSize = 0xC;
-        private readonly int count = Main.Config.ORAS ? 0x3B : 0xC;
+        private readonly int count = Main.Config.ORAS ? 0x3B : 0xD;
         private EncounterStatic6[] EncounterData;
         private readonly string[] itemlist = Main.Config.GetText(TextName.ItemNames);
         private readonly string[] specieslist = Main.Config.GetText(TextName.SpeciesNames);


### PR DESCRIPTION
Pretty straightforward fix. We've been doing this in Universal Pokemon Randomizer ZX for nearly two years at this point, so I'm almost certain this is correct.

![image](https://user-images.githubusercontent.com/12245827/170845226-da0ec9e8-47c0-42db-acbe-479a738b929c.png)
